### PR TITLE
Formatter: respect .gitignore and run in parallel

### DIFF
--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -1090,7 +1090,8 @@ export JSON_LINE_WIDTH=180
 # Formatters
 _fmt_files() {
 	if git rev-parse --is-inside-work-tree &>/dev/null; then
-		git ls-files --cached --others --exclude-standard -- "$@"
+		git ls-files --cached --others --exclude-standard -- "$@" \
+			| grep -Ev '^(\.venv/|target/)'
 	else
 		local find_args=()
 		for pat in "$@"; do


### PR DESCRIPTION
## Summary
- Add `_fmt_files` helper that uses `git ls-files` for file discovery (respects `.gitignore`, faster than `find`), with `find` fallback for non-git directories
- Replace hardcoded `find` calls in `formatter_json`, `formatter_sql`, and `formatter_shell` with `_fmt_files`
- Run the three sub-formatters concurrently via background jobs (`&` + `wait`)

## Test plan
- [ ] Run `formatter` in a git repo with a `.gitignore` — verify ignored files are skipped
- [ ] Run `formatter` outside a git repo — verify `find` fallback still works
- [ ] Verify JSON, SQL, and shell files are still formatted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve the formatter script’s file discovery and execution performance while respecting project ignore rules.

Enhancements:
- Introduce a shared _fmt_files helper that discovers candidate files via git when available, with a find-based fallback for non-git directories.
- Update JSON, SQL, and shell formatter functions to use the common file discovery helper instead of hardcoded find invocations.
- Run JSON, SQL, and shell formatters concurrently within the main formatter wrapper to reduce overall formatting time.