### PR TITLE
Ghostty SSH shortcuts + magpie_mirror; harden scp_mirror

### DIFF
--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -85,6 +85,10 @@ function tailfix() {
 function scp_mirror() {
 	# Usage
 	# $ scp_mirror alex-home ~/.netrc ~/vpn/ ~/.aws ~/.personal ~/.packagr_details
+	#
+	# Files: copied verbatim, perms/mtimes preserved (scp -p).
+	# Directories (trailing slash): contents mirrored via a remote tar pipe, so
+	#   dotfiles inside are included and re-runs do NOT nest (~/vpn/vpn/...).
 	if [ $# -lt 2 ]; then
 		echo "Usage: scp_mirror remote_host path1 [path2 ...]"
 		return 1
@@ -107,14 +111,19 @@ function scp_mirror() {
 		local rel_path="${local_path#$HOME/}"
 		local remote_path="$remote_home/$rel_path"
 
-		mkdir -p "$(dirname "$local_path")"
-
 		if [[ "$path" == */ ]]; then
-			echo "Copying contents of $host:$remote_path to $local_path"
-			scp -r "$host:${remote_path%/}/*" "$local_path"
+			# Directory mirror: strip trailing slash, tar-pipe contents in.
+			local local_dir="${local_path%/}"
+			local remote_dir="${remote_path%/}"
+			local rel_dir="${rel_path%/}"
+			mkdir -p "$local_dir"
+			echo "Mirroring contents of $host:$remote_dir/ to $local_dir/"
+			ssh "$host" "tar -C \"$remote_home\" -cf - \"$rel_dir\"" |
+				tar -C "$HOME" -xf -
 		else
+			mkdir -p "$(dirname "$local_path")"
 			echo "Copying $host:$remote_path to $local_path"
-			scp -r "$host:$remote_path" "$local_path"
+			scp -rp "$host:$remote_path" "$local_path"
 		fi
 	done
 }
@@ -1293,6 +1302,27 @@ function iterm2_fix_keys() {
 	/usr/libexec/PlistBuddy -c "Add :GlobalKeyMap:0x65-0x100000:Action integer 26" "$plist"
 	/usr/libexec/PlistBuddy -c "Add :GlobalKeyMap:0x65-0x100000:Text string ''" "$plist"
 	echo "GlobalKeyMap updated — open iTerm2 now"
+}
+
+# magpie_mirror — pull a curated set of credential / config files from another
+# machine (typically over Tailscale). Magpies are notorious for collecting
+# shiny things, which is exactly what credentials are.
+# Directories are passed with trailing slashes so scp_mirror mirrors contents
+# (no ~/vpn/vpn/vpn/… nesting on repeat runs).
+magpie_mirror() {
+	if [ $# -ne 1 ]; then
+		echo "Usage: magpie_mirror <host>"
+		echo "  Mirrors personal config/credentials from <host> onto this machine."
+		return 1
+	fi
+	scp_mirror "$1" \
+		~/.personal \
+		~/.netrc \
+		~/vpn/ \
+		~/.aws/ \
+		~/.cargo/credentials.toml \
+		~/.claude/CLAUDE.md \
+		~/.ssh/aws_key_dublin.pem
 }
 
 # Fun

--- a/dotfiles/ghostty/config
+++ b/dotfiles/ghostty/config
@@ -1,7 +1,7 @@
 # Armada theme — ported from iTerm2 / Terminator
 
 font-family = FiraCode Nerd Font
-font-size = 9
+font-size = 13
 
 background = 001a22
 foreground = b8ccd6
@@ -34,3 +34,9 @@ confirm-close-surface = false
 
 keybind = cmd+o=new_split:right
 keybind = cmd+e=new_split:down
+
+# Tailscale SSH shortcuts — types the command into the focused surface.
+keybind = ctrl+shift+1=text:"ssh alex-work\n"
+keybind = ctrl+shift+2=text:"ssh alex-home\n"
+keybind = ctrl+shift+3=text:"ssh dellxps\n"
+keybind = ctrl+shift+4=text:"ssh alexs-macbook-air\n"


### PR DESCRIPTION
## Summary

- **Ghostty font size** bumped from 9 → 13 so Ghostty renders at roughly the same visual size as iTerm2 (12) on Retina; Ghostty's own default.
- **Ghostty SSH keybinds** added: `ctrl+shift+1..4` type `ssh alex-work`, `ssh alex-home`, `ssh dellxps`, `ssh alexs-macbook-air` respectively. `ctrl+shift` chosen over `cmd+shift` so the bindings also fire on Ubuntu (where Ghostty maps `cmd` → Super, and GNOME grabs `Super+Shift+<digit>` for workspace switching).
- **`magpie_mirror <host>`** added to `.bash_aliases` — a one-arg wrapper that pulls a curated set of personal files (`~/.personal`, `~/.netrc`, `~/vpn/`, `~/.aws/`, `~/.cargo/credentials.toml`, `~/.claude/CLAUDE.md`, `~/.ssh/aws_key_dublin.pem`) from another machine over SSH. Named for the bird that famously collects shiny things.
- **`scp_mirror` hardened** while I was in there:
  - Added `scp -p` to preserve perms/mtimes (so `.pem` keys land at `600`).
  - `mkdir -p "$local_dir"` before mirroring a directory, so first-run on a fresh machine no longer fails when the target dir doesn't exist.
  - Replaced the remote-glob directory copy (`host:dir/*`) with a `ssh host "tar -C ~ -cf - dir"` | `tar -C ~ -xf -` pipe. This (a) includes dotfiles *inside* the directory (the glob skipped them), and (b) can't produce `~/vpn/vpn/vpn/…` nesting on re-runs.

## Test plan

- [ ] Open Ghostty on macOS, confirm font size looks right next to iTerm2.
- [ ] Press `ctrl+shift+1..4` at an empty Ghostty prompt and confirm the SSH command is typed + executed.
- [ ] On Ubuntu (once synced), confirm the same `ctrl+shift+N` bindings fire (no GNOME conflict).
- [ ] `magpie_mirror alex-work` on a fresh-ish machine, confirm all seven paths land in the expected locations and `~/.ssh/aws_key_dublin.pem` has mode `600`.
- [ ] Run `magpie_mirror` twice and confirm no `~/vpn/vpn/` or `~/.aws/.aws/` nesting.
- [ ] `shellcheck` / `shfmt -d` show no new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a reusable shell alias to mirror personal config/credential files from another host and harden the underlying scp-based mirroring logic, while updating Ghostty defaults for font sizing and SSH shortcuts.

New Features:
- Add magpie_mirror helper to fetch a curated set of personal config and credential files from a remote host via scp_mirror.
- Add Ghostty SSH keyboard shortcuts to quickly initiate SSH sessions to commonly used hosts.

Enhancements:
- Harden scp_mirror so directory mirrors include dotfiles, avoid nested directory paths on repeat runs, ensure target directories exist, and preserve file permissions and timestamps.
- Adjust Ghostty font size to better match iTerm2’s visual sizing on Retina displays.