### PR TITLE
Fix Ghostty install on Ubuntu: match .deb by VERSION_ID

### DIFF
--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -602,29 +602,23 @@ install_duf() {
 install_ghostty() {
 	print_function_name
 	# Install / upgrade Ghostty via the mkasberg community .deb, which tracks
-	# upstream releases. Always fetch the latest published asset.
+	# upstream releases. Asset names are suffixed with the Ubuntu VERSION_ID
+	# (e.g. ghostty_1.3.1-0.ppa2_amd64_25.10.deb), not the codename, so match
+	# on `lsb_release -rs`.
 	local arch
 	arch=$(github_arch deb)
+	local ubuntu_version
+	ubuntu_version=$(lsb_release -rs)
 	local release_json
 	release_json=$(curl -fsSL https://api.github.com/repos/mkasberg/ghostty-ubuntu/releases/latest)
-	local ubuntu_codename
-	ubuntu_codename=$(lsb_release -cs)
 	local deb_url
 	deb_url=$(echo "$release_json" |
 		grep -oE '"browser_download_url": *"[^"]*\.deb"' |
 		cut -d'"' -f4 |
-		grep "_${ubuntu_codename}_${arch}\.deb$" |
+		grep "_${arch}_${ubuntu_version}\.deb$" |
 		head -n1)
 	if [ -z "$deb_url" ]; then
-		# Fall back to any matching arch if no codename-specific asset exists
-		deb_url=$(echo "$release_json" |
-			grep -oE '"browser_download_url": *"[^"]*\.deb"' |
-			cut -d'"' -f4 |
-			grep "_${arch}\.deb$" |
-			head -n1)
-	fi
-	if [ -z "$deb_url" ]; then
-		log "Could not locate a Ghostty .deb for ${ubuntu_codename}/${arch}"
+		log "Could not locate a Ghostty .deb for Ubuntu ${ubuntu_version}/${arch}"
 		return 1
 	fi
 	log "Downloading Ghostty from $deb_url"


### PR DESCRIPTION
## Summary
- `install_ghostty` was matching mkasberg .deb assets by Ubuntu codename (`_${codename}_${arch}.deb`), but the release assets are named by **VERSION_ID** — e.g. `ghostty_1.3.1-0.ppa2_amd64_25.10.deb`. The primary match always missed, and the fallback grepping `_${arch}.deb$` matched nothing either (every asset has a version/codename suffix), so on fresh 25.10 the function returned empty-handed.
- Switch the matcher to `_${arch}_$(lsb_release -rs).deb$` and drop the dead fallback so we fail loudly rather than silently installing another release's .deb.

Verified locally on Ubuntu 25.10 Questing: `ghostty_1.3.1-0.ppa2_amd64_25.10.deb` now resolves and installs cleanly (pulling `libgtk4-layer-shell0` from `questing/universe`). `ghostty --version` reports `1.3.1`.

## Test plan
- [x] Lint: `shfmt -d tools/setup_ubuntu.sh` is clean (shellcheck has only pre-existing warnings unrelated to this change)
- [x] Install verified on Ubuntu 25.10 / amd64
- [ ] Re-run end-to-end via `source setup_entry.sh` on a fresh 25.10 box
- [ ] Spot-check on Ubuntu 24.04 (should pick `_amd64_24.04.deb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix Ghostty installation on Ubuntu by matching .deb assets using VERSION_ID instead of codename and failing explicitly when no matching asset exists.