### PR TITLE
Fix Ghostty SSH keybinds typing literal quote chars

### DIFF
--- a/dotfiles/ghostty/config
+++ b/dotfiles/ghostty/config
@@ -36,7 +36,7 @@ keybind = cmd+o=new_split:right
 keybind = cmd+e=new_split:down
 
 # Tailscale SSH shortcuts — types the command into the focused surface.
-keybind = ctrl+shift+1=text:"ssh alex-work\n"
-keybind = ctrl+shift+2=text:"ssh alex-home\n"
-keybind = ctrl+shift+3=text:"ssh dellxps\n"
-keybind = ctrl+shift+4=text:"ssh alexs-macbook-air\n"
+keybind = ctrl+shift+1=text:ssh alex-work\n
+keybind = ctrl+shift+2=text:ssh alex-home\n
+keybind = ctrl+shift+3=text:ssh dellxps\n
+keybind = ctrl+shift+4=text:ssh alexs-macbook-air\n


### PR DESCRIPTION
## Summary
- Ghostty's `text:` keybind action takes the raw bytes after the colon and processes Zig-style escape sequences, but does **not** strip surrounding quotes.
- The wrapping `"…"` around each `ssh …\n` was being typed into the shell verbatim, leaving bash in a PS2 continuation (`>` / `∙`) waiting for a closing quote instead of running the ssh command.
- Drops the quotes; spaces are fine unquoted since the binding parser only splits on `=` / `:`.

## Test plan
- [ ] Copy updated config to `~/.config/ghostty/config` (or re-run `setup_entry.sh`).
- [ ] Reload Ghostty config and press Ctrl+Shift+1 — expect `ssh alex-work` to run cleanly.
- [ ] Repeat for Ctrl+Shift+2/3/4 (`alex-home`, `dellxps`, `alexs-macbook-air`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix Ghostty SSH keybindings that previously inserted literal quote characters and left the shell waiting for a closing quote.