### PR TITLE
Ghostty: ctrl+shift+w closes surface, shrink default font to 10

### DIFF
--- a/dotfiles/ghostty/config
+++ b/dotfiles/ghostty/config
@@ -1,7 +1,7 @@
 # Armada theme — ported from iTerm2 / Terminator
 
 font-family = FiraCode Nerd Font
-font-size = 11
+font-size = 10
 
 background = 001a22
 foreground = b8ccd6
@@ -35,6 +35,7 @@ keybind = cmd+o=new_split:down
 keybind = cmd+e=new_split:right
 keybind = ctrl+shift+o=new_split:down
 keybind = ctrl+shift+e=new_split:right
+keybind = ctrl+shift+w=close_surface
 
 # Tailscale SSH shortcuts — types the command into the focused surface.
 keybind = ctrl+shift+1=text:ssh alex-work\n


### PR DESCRIPTION
## Summary
- Add `ctrl+shift+w=close_surface` so the shortcut closes just the focused split/tab instead of the whole Ghostty instance (mirrors Terminator behaviour).
- Drop default `font-size` from 11 to 10.

## Test plan
- [ ] Reload Ghostty, open a split, hit `ctrl+shift+w` → only the split closes.
- [ ] Confirm new font size renders correctly on both macOS and Ubuntu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust Ghostty terminal configuration to refine default appearance and keybindings.

New Features:
- Add a Ctrl+Shift+W shortcut that closes only the focused surface (split/tab) instead of the entire Ghostty instance.

Enhancements:
- Reduce the default Ghostty font size from 11 to 10 for a more compact terminal layout.