### PR TITLE
Ghostty: cut new-window latency; relocate gsettings out of .bashrc

### DIFF
--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -99,12 +99,6 @@ fi
 # colored GCC warnings and errors
 #export GCC_COLORS='error=01;31:warning=01;35:note=01;36:caret=01;32:locus=01:quote=01'
 
-# gsettings (Linux/GNOME only)
-if [ "$(uname)" = "Linux" ] && command -v gsettings >/dev/null 2>&1; then
-	gsettings set org.gnome.desktop.interface text-scaling-factor 0.95
-	gsettings set org.gnome.desktop.interface cursor-size 24
-fi
-
 # some more ls aliases
 alias ll='ls -alF'
 alias la='ls -A'

--- a/dotfiles/ghostty/config
+++ b/dotfiles/ghostty/config
@@ -31,6 +31,11 @@ bold-is-bright = true
 copy-on-select = clipboard
 confirm-close-surface = false
 
+# Linux perf: skip per-surface systemd transient scope (saves ~50–200ms on
+# new windows/splits), keep one process for all windows.
+linux-cgroup = false
+gtk-single-instance = true
+
 keybind = cmd+o=new_split:down
 keybind = cmd+e=new_split:right
 keybind = ctrl+shift+o=new_split:down

--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -599,6 +599,16 @@ install_duf() {
 	duf --version
 }
 
+configure_gnome() {
+	print_function_name
+	# One-shot GNOME interface tweaks. Persistent in dconf, so this only
+	# needs to run at machine setup — not on every shell start.
+	if command -v gsettings >/dev/null 2>&1; then
+		gsettings set org.gnome.desktop.interface text-scaling-factor 0.95
+		gsettings set org.gnome.desktop.interface cursor-size 24
+	fi
+}
+
 install_ghostty() {
 	print_function_name
 	# Install / upgrade Ghostty via the mkasberg community .deb, which tracks
@@ -951,6 +961,7 @@ main() {
 	run_function install_duf
 	run_function install_gum
 	run_function install_ghostty
+	run_function configure_gnome
 	run_function install_delta
 	run_function install_lazygit
 	run_function install_lazydocker


### PR DESCRIPTION
## Summary
- **ghostty config:** `linux-cgroup = false` skips creating a per-surface systemd transient scope on every new window/split (saves ~50–200ms on Linux). `gtk-single-instance = true` makes single-instance explicit so windows reuse the running process.
- **.bashrc:** drop the `gsettings set …` block. The values are persisted in dconf — running gsettings on every interactive shell forks a process for nothing.
- **setup_ubuntu.sh:** new `configure_gnome()` function runs the same `gsettings` calls once at machine setup, replacing the per-shell version.

## Why
Switched from terminator → ghostty and new windows felt sluggish. Profiling showed (a) a per-surface systemd cgroup setup on each new ghostty window and (b) `gsettings` forks on every interactive shell from `.bashrc`. Both are removed/relocated here.

## Test plan
- [ ] Fully quit ghostty (close all windows) and relaunch — confirm new windows/splits open faster
- [ ] Verify `gsettings get org.gnome.desktop.interface text-scaling-factor` still returns `0.95` and `cursor-size` returns `24` (dconf-persisted from prior runs)
- [ ] Run `bash setup_ubuntu.sh` on a fresh box and confirm `configure_gnome` applies both values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Optimize terminal startup behavior on Linux by moving GNOME interface configuration to one-time system setup and updating Ghostty configuration for faster, single-instance window creation.

Enhancements:
- Add a one-shot GNOME configuration step to the Ubuntu setup script to apply interface tweaks via gsettings during machine setup.
- Update Ghostty configuration to avoid per-window systemd cgroup creation and enforce single-instance behavior for new windows.
- Remove per-shell gsettings calls from .bashrc to reduce overhead on interactive shell startup.