### PR TITLE
Ghostty: fix linux-cgroup value (false -> never)

### DIFF
--- a/dotfiles/ghostty/config
+++ b/dotfiles/ghostty/config
@@ -33,7 +33,7 @@ confirm-close-surface = false
 
 # Linux perf: skip per-surface systemd transient scope (saves ~50–200ms on
 # new windows/splits), keep one process for all windows.
-linux-cgroup = false
+linux-cgroup = never
 gtk-single-instance = true
 
 keybind = cmd+o=new_split:down


### PR DESCRIPTION
## Summary
- `linux-cgroup` is an enum (`never|always|single-instance`), not a boolean. The previous value `false` triggered a config-load error: `invalid value "false"`.
- Switched to `never`, which preserves the original perf intent (skip the per-surface systemd transient scope).

## Test plan
- [x] `ghostty +validate-config` passes silently with the new value
- [ ] Open Ghostty and confirm no config error banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Fix Ghostty configuration load error by replacing the invalid linux-cgroup value `false` with the enum value `never`.