### PR TITLE
Ghostty: black split divider + equalize_splits keybind

### DIFF
--- a/dotfiles/ghostty/config
+++ b/dotfiles/ghostty/config
@@ -31,6 +31,8 @@ bold-is-bright = true
 copy-on-select = clipboard
 confirm-close-surface = false
 
+split-divider-color = #000000
+
 # Linux perf: skip per-surface systemd transient scope (saves ~50–200ms on
 # new windows/splits), keep one process for all windows.
 linux-cgroup = never
@@ -41,6 +43,7 @@ keybind = cmd+e=new_split:right
 keybind = ctrl+shift+o=new_split:down
 keybind = ctrl+shift+e=new_split:right
 keybind = ctrl+shift+w=close_surface
+keybind = ctrl+shift+0=equalize_splits
 
 # Tailscale SSH shortcuts — types the command into the focused surface.
 keybind = ctrl+shift+1=text:ssh alex-work\n


### PR DESCRIPTION
## Summary
- Set `split-divider-color = #000000` so split seams stand out against the dark Armada background.
- Bind `ctrl+shift+0` to `equalize_splits` as the closest substitute for Terminator's double-click-snap-to-middle on a divider (Ghostty has no mouse-on-divider action).

## Test plan
- [ ] Reload Ghostty config (`ctrl+shift+,`)
- [ ] Open two splits — divider visibly darker than before
- [ ] Drag one split larger, press `ctrl+shift+0`, splits snap back to equal size

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Configure Ghostty splits appearance and add a keyboard shortcut for resizing splits.

New Features:
- Add a ctrl+shift+0 keybinding to equalize terminal splits in Ghostty.

Enhancements:
- Change the Ghostty split divider color to black to improve visual contrast between panes.