### PR TITLE
apt_upgrader: recover from interrupted dpkg state

### DIFF
--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -244,6 +244,7 @@ function apt_upgrader() {
 	print_function_name
 	sudo find /etc/apt/sources.list.d/ -name "*.sources" -exec grep -l questing {} \; -exec rm -v {} \;
 	sudo systemctl stop packagekit
+	sudo dpkg --configure -a
 	clean_broken_repos
 	sudo apt update -y
 	sudo apt upgrade -y


### PR DESCRIPTION
## Summary
- Add `sudo dpkg --configure -a` to `apt_upgrader` so a half-finished dpkg state is resolved before any apt update/upgrade work.

## Why
Hit `E: dpkg was interrupted, you must manually run 'sudo dpkg --configure -a' to correct the problem.` during a normal `apt_upgrader` run — the function couldn't recover on its own. This is a no-op when dpkg is clean, so it's safe to always run.

## Test plan
- [ ] Run `apt_upgrader` on a clean machine — should behave as before (dpkg --configure -a is a no-op).
- [ ] Run `apt_upgrader` after an interrupted dpkg (e.g. Ctrl-C'd install) — should self-recover and complete the upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Handle interrupted dpkg states in apt_upgrader by running sudo dpkg --configure -a prior to apt operations.