### PR TITLE
install_espanso: drop trailing espanso --version (was causing FAIL)

### DIFF
--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -482,7 +482,6 @@ install_espanso() {
 	else
 		espanso service start
 	fi
-	espanso --version
 }
 
 install_and_setup_docker() {


### PR DESCRIPTION
## Summary
Follow-up to #181. \`espanso --version\` exits with code 1 (upstream quirk) despite printing the version correctly, so when it was the last command in the function \`run_function\` reported \`FAIL install_espanso\` even though everything had succeeded.

The version is already logged earlier — the trailing call was redundant noise. Removing it lets the function return 0.

## Test plan
- [x] Reproduced the FAIL with the previous code (under \`set -e\` + \`pipefail\` and \`run_function\`)
- [x] After the fix: \`<<< install_espanso done\` and \`failed=none\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Avoid reporting install_espanso as failed by dropping a trailing espanso --version command that exits with a non-zero status despite successful installation.