### PR TITLE
install_pyenv: resolve pyenv global to concrete installed patch

### DIFF
--- a/tools/common.sh
+++ b/tools/common.sh
@@ -205,7 +205,9 @@ install_pyenv() {
 			pyenv install -f "$latest"
 		done
 	fi
-	pyenv global $DEFAULT_PYTHON_VERSION
+	# Resolve the concrete installed patch (e.g. 3.14 -> 3.14.5); pyenv global
+	# requires an exact version name, not a major.minor prefix.
+	pyenv global "$(pyenv latest "$DEFAULT_PYTHON_VERSION")"
 
 	# Install pyenv-virtualenv plugin
 	local venv_folder


### PR DESCRIPTION
## Summary
- `install_pyenv` set `pyenv global $DEFAULT_PYTHON_VERSION` where `DEFAULT_PYTHON_VERSION` is a **major.minor track** (`"3.14"`). pyenv installs concrete dirs (`3.14.5`), and `pyenv global` requires an *exact* version name — so `pyenv global 3.14` never resolves and silently falls back to system Python.
- Knock-on effect: bare `python` then fails and triggers pyenv's slow all-versions *"command not found"* scan (~0.3s warm, >500ms cold). That exceeds Starship's default `command_timeout`, printing a `[WARN] ... timed out` on every `cd` into a Python directory.
- Fix: resolve the concrete installed patch with `pyenv global "$(pyenv latest "$DEFAULT_PYTHON_VERSION")"` (→ `3.14.5`). Keeps `DEFAULT_PYTHON_VERSION` as the `3.14` track so the Ubuntu install loop's prefix regex is unchanged, and auto-tracks future patch bumps without edits.

## Test plan
- [x] `pyenv latest 3.14` → `3.14.5` on pyenv 2.6.31
- [ ] Run `setup_ubuntu.sh` (or just `install_pyenv`) on a fresh box and confirm `pyenv global` reports `3.14.5` and `python --version` works
- [ ] Confirm the Starship `command_timeout` WARN no longer appears when `cd`-ing into a Python repo

## Note / possible follow-up
The macOS branch has the same latent bug at `tools/common.sh:171` — `$PYENV_ROOT/versions/$DEFAULT_PYTHON_VERSION/bin/python3` (i.e. `versions/3.14/bin/...`) never exists, so the arch-verification `[ -f "$python_bin" ]` check is currently dead. Left out of this PR to keep it focused; happy to fix in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Update install_pyenv to set pyenv global using pyenv latest for the configured major.minor version, avoiding fallback to system Python and slow command resolution.