### PR TITLE
Preserve comments when formatting JSON/JSON5

### DIFF
--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -1242,101 +1242,348 @@ formatter_json() {
 	_fmt_files '*.json' '*.json5' | while read -r file; do
 		log "Processing $file"
 
-		ext="${file##*.}"
+		# Reformat in place: sort keys, align colons, pack scalar arrays
+		# wide, and PRESERVE comments. Parses json and json5 natively (no
+		# json5->json pre-pass), so // and /* */ comments survive on both.
+		python3 - "$file" "$line_width" <<-'PYEOF' 2>/dev/null || {
+			import json
+			import sys
 
-		# Convert json5 to json first if needed
-		if [[ "$ext" == "json5" ]]; then
-			json5 "$file" --out-file "$file"
-		fi
+			LINE_WIDTH = int(sys.argv[2])
 
-		# Sort keys and align colons using Python
-		python3 -c '
-import json
-import sys
-import os
 
-LINE_WIDTH = int(sys.argv[2])
+			class Tok:
+			    __slots__ = ("kind", "value", "line")
 
-def compact_json(obj):
-    """Return compact JSON with sorted keys."""
-    if isinstance(obj, dict):
-        if not obj:
-            return "{}"
-        parts = []
-        for k in sorted(obj.keys()):
-            parts.append(f"{json.dumps(k)}: {compact_json(obj[k])}")
-        return "{" + ", ".join(parts) + "}"
-    elif isinstance(obj, list):
-        if not obj:
-            return "[]"
-        return "[" + ", ".join(compact_json(x) for x in obj) + "]"
-    else:
-        return json.dumps(obj)
+			    def __init__(self, kind, value, line):
+			        self.kind = kind
+			        self.value = value
+			        self.line = line
 
-def align_json(obj, indent=0):
-    ind = "  " * indent
-    current_col = len(ind)
 
-    if isinstance(obj, dict):
-        if not obj:
-            return "{}"
-        # Try compact form first
-        compact = compact_json(obj)
-        if "\n" not in compact and current_col + len(compact) < LINE_WIDTH:
-            return compact
-        sorted_keys = sorted(obj.keys())
-        max_len = max(len(json.dumps(k)) for k in sorted_keys)
-        lines = ["{"]
-        for i, key in enumerate(sorted_keys):
-            key_str = json.dumps(key)
-            value_str = align_json(obj[key], indent + 1)
-            padding = " " * (max_len - len(key_str))
-            comma = "," if i < len(sorted_keys) - 1 else ""
-            lines.append(f"{ind}  {key_str}{padding}: {value_str}{comma}")
-        lines.append(f"{ind}}}")
-        return "\n".join(lines)
-    elif isinstance(obj, list):
-        if not obj:
-            return "[]"
-        # Try compact form first
-        compact = compact_json(obj)
-        if "\n" not in compact and current_col + len(compact) < LINE_WIDTH:
-            return compact
-        # Pack scalar items wide (multiple per line)
-        if all(not isinstance(x, (dict, list)) for x in obj):
-            inner_ind = ind + "  "
-            lines = ["["]
-            current_line = inner_ind
-            for i, item in enumerate(obj):
-                value_str = json.dumps(item)
-                suffix = ", " if i < len(obj) - 1 else ""
-                entry = value_str + suffix
-                if current_line == inner_ind:
-                    current_line += entry
-                elif len(current_line) + len(entry) <= LINE_WIDTH:
-                    current_line += entry
-                else:
-                    lines.append(current_line.rstrip())
-                    current_line = inner_ind + entry
-            if current_line.strip():
-                lines.append(current_line.rstrip())
-            lines.append(f"{ind}]")
-            return "\n".join(lines)
-        lines = ["["]
-        for i, item in enumerate(obj):
-            value_str = align_json(item, indent + 1)
-            comma = "," if i < len(obj) - 1 else ""
-            lines.append(f"{ind}  {value_str}{comma}")
-        lines.append(f"{ind}]")
-        return "\n".join(lines)
-    else:
-        return json.dumps(obj)
+			def tokenize(s):
+			    tokens = []
+			    i = 0
+			    n = len(s)
+			    line = 0
+			    while i < n:
+			        c = s[i]
+			        if c == "\n":
+			            line += 1
+			            i += 1
+			            continue
+			        if c in " \t\r":
+			            i += 1
+			            continue
+			        if c == "/" and i + 1 < n and s[i + 1] == "/":
+			            j = i + 2
+			            while j < n and s[j] != "\n":
+			                j += 1
+			            tokens.append(Tok("comment", s[i:j].rstrip(), line))
+			            i = j
+			            continue
+			        if c == "/" and i + 1 < n and s[i + 1] == "*":
+			            j = i + 2
+			            while j < n and not (s[j] == "*" and j + 1 < n and s[j + 1] == "/"):
+			                j += 1
+			            j = min(j + 2, n)
+			            text = s[i:j]
+			            tokens.append(Tok("comment", text, line))
+			            line += text.count("\n")
+			            i = j
+			            continue
+			        if c == '"' or c == "'":
+			            quote = c
+			            j = i + 1
+			            buf = []
+			            while j < n:
+			                if s[j] == "\\":
+			                    buf.append(s[j : j + 2])
+			                    j += 2
+			                    continue
+			                if s[j] == quote:
+			                    break
+			                buf.append(s[j])
+			                j += 1
+			            tokens.append(Tok("string", (quote, "".join(buf)), line))
+			            i = j + 1
+			            continue
+			        if c in "{}[]:,":
+			            tokens.append(Tok("punct", c, line))
+			            i += 1
+			            continue
+			        j = i
+			        while j < n and s[j] not in " \t\r\n" and s[j] not in "{}[]:,/\"'":
+			            j += 1
+			        tokens.append(Tok("word", s[i:j], line))
+			        i = j
+			    return tokens
 
-with open(sys.argv[1], "r") as f:
-    data = json.load(f)
-with open(sys.argv[1], "w") as f:
-    f.write(align_json(data) + "\n")
-' "$file" "$line_width" 2>/dev/null || {
+
+			def decode_string(quote, raw):
+			    out = []
+			    i = 0
+			    n = len(raw)
+			    while i < n:
+			        ch = raw[i]
+			        if ch == "\\" and i + 1 < n:
+			            nxt = raw[i + 1]
+			            simple = {"n": "\n", "t": "\t", "r": "\r", "b": "\b", "f": "\f", "v": "\v", "0": "\0"}
+			            if nxt in simple:
+			                out.append(simple[nxt])
+			                i += 2
+			            elif nxt == "u":
+			                out.append(chr(int(raw[i + 2 : i + 6], 16)))
+			                i += 6
+			            elif nxt == "x":
+			                out.append(chr(int(raw[i + 2 : i + 4], 16)))
+			                i += 4
+			            elif nxt == "\n":
+			                i += 2
+			            else:
+			                out.append(nxt)
+			                i += 2
+			            continue
+			        out.append(ch)
+			        i += 1
+			    return "".join(out)
+
+
+			def normalize_word(word):
+			    if word in ("true", "false", "null"):
+			        return word
+			    stripped = word.lstrip("+")
+			    if stripped.lstrip("-") in ("Infinity", "NaN"):
+			        return stripped
+			    low = stripped.lower()
+			    if low.startswith("0x") or low.startswith("-0x"):
+			        return str(int(stripped, 16))
+			    try:
+			        return str(int(stripped))
+			    except ValueError:
+			        pass
+			    try:
+			        float(stripped)
+			        return stripped
+			    except ValueError:
+			        return json.dumps(word)
+
+
+			class Parser:
+			    def __init__(self, tokens):
+			        self.toks = tokens
+			        self.pos = 0
+
+			    def at(self):
+			        return self.toks[self.pos] if self.pos < len(self.toks) else None
+
+			    def comments(self):
+			        out = []
+			        while self.pos < len(self.toks) and self.toks[self.pos].kind == "comment":
+			            out.append(self.toks[self.pos].value)
+			            self.pos += 1
+			        return out
+
+			    def parse_value(self):
+			        tok = self.toks[self.pos]
+			        if tok.kind == "punct" and tok.value == "{":
+			            return self.parse_object()
+			        if tok.kind == "punct" and tok.value == "[":
+			            return self.parse_array()
+			        if tok.kind == "string":
+			            self.pos += 1
+			            q, raw = tok.value
+			            return ("scalar", json.dumps(decode_string(q, raw)))
+			        if tok.kind == "word":
+			            self.pos += 1
+			            return ("scalar", normalize_word(tok.value))
+			        raise ValueError("unexpected token: %r" % (tok.value,))
+
+			    def consume_tail(self, value_line):
+			        # optional trailing comment + comma in either order
+			        trailing = None
+			        if (
+			            self.pos < len(self.toks)
+			            and self.toks[self.pos].kind == "comment"
+			            and self.toks[self.pos].line == value_line
+			        ):
+			            trailing = self.toks[self.pos].value
+			            self.pos += 1
+			        if self.pos < len(self.toks) and self.toks[self.pos].kind == "punct" and self.toks[self.pos].value == ",":
+			            comma_line = self.toks[self.pos].line
+			            self.pos += 1
+			            if (
+			                trailing is None
+			                and self.pos < len(self.toks)
+			                and self.toks[self.pos].kind == "comment"
+			                and self.toks[self.pos].line == comma_line
+			            ):
+			                trailing = self.toks[self.pos].value
+			                self.pos += 1
+			        return trailing
+
+			    def parse_object(self):
+			        self.pos += 1  # '{'
+			        members = []
+			        while True:
+			            leading = self.comments()
+			            tok = self.toks[self.pos]
+			            if tok.kind == "punct" and tok.value == "}":
+			                self.pos += 1
+			                return ("object", members, leading)
+			            if tok.kind == "string":
+			                q, raw = tok.value
+			                key = decode_string(q, raw)
+			            elif tok.kind == "word":
+			                key = tok.value
+			            else:
+			                raise ValueError("expected key, got %r" % (tok.value,))
+			            self.pos += 1
+			            leading += self.comments()
+			            assert self.toks[self.pos].value == ":", "expected colon"
+			            self.pos += 1
+			            leading += self.comments()
+			            value = self.parse_value()
+			            value_line = self.toks[self.pos - 1].line
+			            trailing = self.consume_tail(value_line)
+			            members.append({"leading": leading, "key": key, "value": value, "trailing": trailing})
+
+			    def parse_array(self):
+			        self.pos += 1  # '['
+			        elems = []
+			        while True:
+			            leading = self.comments()
+			            tok = self.toks[self.pos]
+			            if tok.kind == "punct" and tok.value == "]":
+			                self.pos += 1
+			                return ("array", elems, leading)
+			            value = self.parse_value()
+			            value_line = self.toks[self.pos - 1].line
+			            trailing = self.consume_tail(value_line)
+			            elems.append({"leading": leading, "value": value, "trailing": trailing})
+
+
+			def compact_json(node):
+			    kind = node[0]
+			    if kind == "scalar":
+			        return node[1]
+			    if kind == "object":
+			        members, dangling = node[1], node[2]
+			        if dangling:
+			            return None
+			        items = []
+			        for m in members:
+			            if m["leading"] or m["trailing"]:
+			                return None
+			            v = compact_json(m["value"])
+			            if v is None:
+			                return None
+			            items.append((m["key"], v))
+			        if not items:
+			            return "{}"
+			        items.sort(key=lambda x: x[0])
+			        return "{" + ", ".join(json.dumps(k) + ": " + v for k, v in items) + "}"
+			    members, dangling = node[1], node[2]
+			    if dangling:
+			        return None
+			    parts = []
+			    for e in members:
+			        if e["leading"] or e["trailing"]:
+			            return None
+			        v = compact_json(e["value"])
+			        if v is None:
+			            return None
+			        parts.append(v)
+			    if not parts:
+			        return "[]"
+			    return "[" + ", ".join(parts) + "]"
+
+
+			def align_json(node, indent=0):
+			    ind = "  " * indent
+			    current_col = len(ind)
+			    kind = node[0]
+			    if kind == "scalar":
+			        return node[1]
+
+			    if kind == "object":
+			        members, dangling = node[1], node[2]
+			        if not members and not dangling:
+			            return "{}"
+			        compact = compact_json(node)
+			        if compact is not None and "\n" not in compact and current_col + len(compact) < LINE_WIDTH:
+			            return compact
+			        sm = sorted(members, key=lambda m: m["key"])
+			        max_len = max(len(json.dumps(m["key"])) for m in sm) if sm else 0
+			        lines = ["{"]
+			        for i, m in enumerate(sm):
+			            for c in m["leading"]:
+			                lines.append(f"{ind}  {c}")
+			            key_str = json.dumps(m["key"])
+			            value_str = align_json(m["value"], indent + 1)
+			            padding = " " * (max_len - len(key_str))
+			            comma = "," if i < len(sm) - 1 else ""
+			            trail = f"  {m['trailing']}" if m["trailing"] else ""
+			            lines.append(f"{ind}  {key_str}{padding}: {value_str}{comma}{trail}")
+			        for c in dangling:
+			            lines.append(f"{ind}  {c}")
+			        lines.append(f"{ind}}}")
+			        return "\n".join(lines)
+
+			    elems, dangling = node[1], node[2]
+			    if not elems and not dangling:
+			        return "[]"
+			    compact = compact_json(node)
+			    if compact is not None and "\n" not in compact and current_col + len(compact) < LINE_WIDTH:
+			        return compact
+			    has_comments = bool(dangling) or any(e["leading"] or e["trailing"] for e in elems)
+			    all_scalar = all(e["value"][0] == "scalar" for e in elems)
+			    if all_scalar and not has_comments:
+			        inner_ind = ind + "  "
+			        lines = ["["]
+			        current_line = inner_ind
+			        for i, e in enumerate(elems):
+			            entry = e["value"][1] + (", " if i < len(elems) - 1 else "")
+			            if current_line == inner_ind:
+			                current_line += entry
+			            elif len(current_line) + len(entry) <= LINE_WIDTH:
+			                current_line += entry
+			            else:
+			                lines.append(current_line.rstrip())
+			                current_line = inner_ind + entry
+			        if current_line.strip():
+			            lines.append(current_line.rstrip())
+			        lines.append(f"{ind}]")
+			        return "\n".join(lines)
+			    lines = ["["]
+			    for i, e in enumerate(elems):
+			        for c in e["leading"]:
+			            lines.append(f"{ind}  {c}")
+			        value_str = align_json(e["value"], indent + 1)
+			        comma = "," if i < len(elems) - 1 else ""
+			        trail = f"  {e['trailing']}" if e["trailing"] else ""
+			        lines.append(f"{ind}  {value_str}{comma}{trail}")
+			    for c in dangling:
+			        lines.append(f"{ind}  {c}")
+			    lines.append(f"{ind}]")
+			    return "\n".join(lines)
+
+
+			with open(sys.argv[1], "r") as f:
+			    text = f.read()
+
+			parser = Parser(tokenize(text))
+			header = parser.comments()
+			root = parser.parse_value()
+			footer = parser.comments()
+
+			out = list(header)
+			out.append(align_json(root, 0))
+			out.extend(footer)
+
+			with open(sys.argv[1], "w") as f:
+			    f.write("\n".join(out) + "\n")
+		PYEOF
 			log "Failed to parse $file, falling back to jq"
 			if command -v jq &>/dev/null; then
 				jq -S '.' "$file" >"$file.tmp" && mv "$file.tmp" "$file"

--- a/tests/formatter/expected.json
+++ b/tests/formatter/expected.json
@@ -1,0 +1,14 @@
+// Top-of-file header comment describing this config.
+{
+  "alpha"  : {
+    "beta" : 2,
+    // nested comment above gamma
+    "gamma": 3
+  },
+  "name"   : "demo",
+  "ports"  : [80, 443, 8080, 22, 25, 3000, 5432, 6379, 9090, 1234, 5678],
+  "retries": 5,
+  "timeout": 30,  // trailing comment on a value
+  // zebra should sort after alpha
+  "zebra"  : true
+}

--- a/tests/formatter/expected.json5
+++ b/tests/formatter/expected.json5
@@ -1,0 +1,14 @@
+// Top-of-file header comment describing this config.
+{
+  "alpha"  : {
+    "beta" : 2,
+    // nested comment above gamma
+    "gamma": 3
+  },
+  "name"   : "demo",
+  "ports"  : [80, 443, 8080, 22, 25, 3000, 5432, 6379, 9090, 1234, 5678],
+  "retries": 5,
+  "timeout": 30,  // trailing comment on a value
+  // zebra should sort after alpha
+  "zebra"  : true
+}

--- a/tests/formatter/input.json
+++ b/tests/formatter/input.json
@@ -1,0 +1,14 @@
+// Top-of-file header comment describing this config.
+{
+  "name": "demo",
+  // zebra should sort after alpha
+  "zebra": true,
+  "alpha": {
+    // nested comment above gamma
+    "gamma": 3,
+    "beta": 2
+  },
+  "ports": [80, 443, 8080, 22, 25, 3000, 5432, 6379, 9090, 1234, 5678],
+  "timeout": 30, // trailing comment on a value
+  "retries": 5
+}

--- a/tests/formatter/input.json5
+++ b/tests/formatter/input.json5
@@ -1,0 +1,14 @@
+// Top-of-file header comment describing this config.
+{
+  name: 'demo',
+  // zebra should sort after alpha
+  zebra: true,
+  alpha: {
+    // nested comment above gamma
+    gamma: 3,
+    beta: 2,
+  },
+  ports: [80, 443, 8080, 22, 25, 3000, 5432, 6379, 9090, 1234, 5678],
+  timeout: 30, // trailing comment on a value
+  retries: 5,
+}

--- a/tests/formatter/run.sh
+++ b/tests/formatter/run.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Self-contained test for formatter_json: proves comments are preserved on both
+# .json and .json5, keys are sorted, colons aligned, and json5 normalises to
+# strict JSON. Copies fixtures to a temp dir so the committed inputs are never
+# reformatted in place. Exits non-zero on any mismatch.
+set -u
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+aliases="$repo_root/dotfiles/.bash_aliases"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+cp "$here/input.json" "$here/input.json5" "$tmp/"
+
+# shellcheck source=/dev/null
+source "$aliases"
+
+(
+	cd "$tmp" || exit 1
+	formatter_json
+)
+
+status=0
+for ext in json json5; do
+	if diff -u "$here/expected.$ext" "$tmp/input.$ext"; then
+		echo "PASS: input.$ext formatted as expected (comments preserved)"
+	else
+		echo "FAIL: input.$ext did not match expected.$ext"
+		status=1
+	fi
+done
+
+if diff -q "$tmp/input.json" "$tmp/input.json5" >/dev/null; then
+	echo "PASS: .json and .json5 produce byte-identical output"
+else
+	echo "FAIL: .json and .json5 output differ"
+	status=1
+fi
+
+exit "$status"


### PR DESCRIPTION
## Summary

`formatter` (the `formatter_json` bash function) reformats JSON/JSON5 files — sorting keys alphabetically, aligning colons, and packing scalar arrays wide. It previously **destroyed all comments** in two places:

1. `json5 "$file" --out-file "$file"` converted json5 → strict JSON, stripping comments and trailing commas.
2. The embedded Python used stdlib `json`, which has no representation for comments.

This replaces both with a small **comment-aware JSON5 parser + emitter** (embedded as a quoted heredoc). It parses `.json` and `.json5` natively — no pre-conversion — so `//` and `/* */` comments survive on both, while keeping every existing behaviour: alphabetical key sort, colon alignment, wide scalar-array packing, the `JSON_LINE_WIDTH` knob, and the `jq -S` fallback.

### Behaviour
- A comment on its own line above a key **travels with that key** when keys are sorted; a trailing same-line comment stays attached to its value.
- `.json5` input is **normalised to strict JSON with comments retained** (unquoted keys → quoted, single → double quotes, trailing commas dropped), so `.json` and `.json5` format identically.

## Tests

New `tests/formatter/` with `.json` / `.json5` fixtures covering a header comment, own-line comments above keys, a trailing comment, out-of-order keys, a scalar array, a nested object, plus json5-only syntax (unquoted keys, single quotes, trailing commas). `run.sh` copies them to a temp dir, sources the real `.bash_aliases`, runs `formatter_json`, and diffs against the expected output.

```
PASS: input.json formatted as expected (comments preserved)
PASS: input.json5 formatted as expected (comments preserved)
PASS: .json and .json5 produce byte-identical output
```

Run with: `bash tests/formatter/run.sh`

## Verification done
- **No regression on comment-free input**: byte-for-byte identical to the old formatter.
- **Malformed input**: `jq` fallback triggers, file left intact, loop continues — no abort.
- **Block comments + idempotency**: `/* … */` preserved; a second pass is a no-op.
- **Lint**: `shellcheck` issue count unchanged (zero new issues in the changed region); `shfmt -d` stable on the heredoc (matched shfmt's canonical `<<-` indentation, important since `formatter_shell` runs `shfmt -w` on this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Preserve comments while reformatting JSON and JSON5 files in the shell formatter.

New Features:
- Add a comment-aware JSON/JSON5 formatter that sorts keys, aligns colons, and packs scalar arrays while retaining line and block comments.
- Support native JSON5 parsing so .json and .json5 inputs are normalised to a consistent strict-JSON-style output.

Enhancements:
- Replace the previous json/json5 formatting pipeline with an embedded Python implementation that handles both formats in one pass and falls back to jq on parse failure.

Tests:
- Add formatter integration tests with JSON and JSON5 fixtures to verify comment preservation, key sorting, colon alignment, and identical output between .json and .json5 inputs.