### PR TITLE
Fix _fmt_files: bypass grep->rg alias so formatters find files

### DIFF
--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -1222,8 +1222,8 @@ export JSON_LINE_WIDTH=180
 # Formatters
 _fmt_files() {
 	if git rev-parse --is-inside-work-tree &>/dev/null; then
-		git ls-files --cached --others --exclude-standard -- "$@" \
-			| grep -Ev '^(\.venv/|target/)'
+		git ls-files --cached --others --exclude-standard -- "$@" |
+			\grep -Ev '^(\.venv/|target/)'
 	else
 		local find_args=()
 		for pat in "$@"; do


### PR DESCRIPTION
## Problem

Running `formatter` did nothing and printed:

```
rg: error parsing flag -E: grep config error: unknown encoding: v
```

`_fmt_files` (the shared file-discovery helper used by `formatter_json`, `formatter_sql`, and `formatter_shell`) piped `git ls-files` into a **bare `grep -Ev`**. On any machine where this repo aliases `grep` to `rg` — which it does whenever `rg` is installed (see the `alias grep='rg'` block in `.bash_aliases`) — the alias rewrote it to `rg -Ev`. `rg` parses `-E v` as `--encoding v` → `unknown encoding: v`, errors out, and emits nothing.

With no output from `_fmt_files`, all three formatters received zero files and silently did nothing, leaving an empty `git diff`.

## Fix

Use `\grep` to bypass the alias (matching the file's existing `\grep`/`\tail` usage in `grepcfix`/`tailfix`), and adopt shfmt's pipe-at-end-of-line style on the same line so the file stays `shfmt`-clean (`formatter_shell` runs `shfmt -w` on it).

## Verification

- **Reproduced** the failure with `grep` aliased to `rg`, and confirmed `\grep` lists files correctly.
- **End-to-end**: sourced the real `.bash_aliases` (so `grep`→`rg` is active) in a temp git repo and ran `formatter_json` — files are now found and formatted (comments preserved, keys sorted, json5 normalised).
- `shfmt -d dotfiles/.bash_aliases` is now fully clean; `shellcheck` issue count unchanged.

Note: this is a pre-existing bug, surfaced while testing #186 (JSON comment preservation) — that feature couldn't run at all until `_fmt_files` returned files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent _fmt_files from failing when grep is aliased to rg so formatters receive the correct file list.