### PR TITLE
Speed up shell startup and slim dotfiles

### DIFF
--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -5,12 +5,12 @@ export KUBECONFIG=~/.kube/config
 alias refresh='source ~/.bashrc'
 alias reload='refresh'
 
-# Make grep always show color and enable Regex, which is normally a default behavior on Linux
-if command -v rg >/dev/null 2>&1; then
-	alias grep='rg'
-else
-	alias grep='grep --color=auto -E'
-fi
+# Make grep always show color and enable extended regex.
+# NOTE: deliberately NOT aliased to rg — rg has different recursion/regex/flag
+# semantics, and the alias was being baked into every function below that calls
+# bare `grep` (alias expansion happens at function-definition time). Use `rg`
+# explicitly when you want ripgrep.
+alias grep='grep --color=auto -E'
 
 ##
 # LS ALIASES
@@ -347,23 +347,20 @@ function diesel_setup() {
 # Python
 function pypath() {
 	export PYTHONPATH=$(pwd)/src:$(pwd)/tests:$PYTHONPATH
-	IFS=:
-	unique_paths=()
-	for path in $PYTHONPATH; do
-		if [[ ! "${unique_paths[*]}" =~ ${path} ]]; then
-			unique_paths+=("$path")
+	# Deduplicate PYTHONPATH, preserving order (exact match, not substring)
+	local -A seen
+	local new=() p parts
+	IFS=: read -ra parts <<<"$PYTHONPATH"
+	for p in "${parts[@]}"; do
+		if [ -n "$p" ] && [ -z "${seen[$p]:-}" ]; then
+			seen["$p"]=1
+			new+=("$p")
 		fi
 	done
-	IFS=$' \t\n'
-
-	new_path=$(
-		IFS=:
-		echo "${unique_paths[*]}"
-	)
-	export PYTHONPATH="$new_path"
-	IFS=:
-	for i in $PYTHONPATH; do echo $i; done
+	IFS=: PYTHONPATH="${new[*]}"
+	export PYTHONPATH
 	unset IFS
+	printf '%s\n' "${new[@]}"
 }
 
 # Version comparison helpers (using sort -V)
@@ -1245,345 +1242,8 @@ formatter_json() {
 		# Reformat in place: sort keys, align colons, pack scalar arrays
 		# wide, and PRESERVE comments. Parses json and json5 natively (no
 		# json5->json pre-pass), so // and /* */ comments survive on both.
-		python3 - "$file" "$line_width" <<-'PYEOF' 2>/dev/null || {
-			import json
-			import sys
-
-			LINE_WIDTH = int(sys.argv[2])
-
-
-			class Tok:
-			    __slots__ = ("kind", "value", "line")
-
-			    def __init__(self, kind, value, line):
-			        self.kind = kind
-			        self.value = value
-			        self.line = line
-
-
-			def tokenize(s):
-			    tokens = []
-			    i = 0
-			    n = len(s)
-			    line = 0
-			    while i < n:
-			        c = s[i]
-			        if c == "\n":
-			            line += 1
-			            i += 1
-			            continue
-			        if c in " \t\r":
-			            i += 1
-			            continue
-			        if c == "/" and i + 1 < n and s[i + 1] == "/":
-			            j = i + 2
-			            while j < n and s[j] != "\n":
-			                j += 1
-			            tokens.append(Tok("comment", s[i:j].rstrip(), line))
-			            i = j
-			            continue
-			        if c == "/" and i + 1 < n and s[i + 1] == "*":
-			            j = i + 2
-			            while j < n and not (s[j] == "*" and j + 1 < n and s[j + 1] == "/"):
-			                j += 1
-			            j = min(j + 2, n)
-			            text = s[i:j]
-			            tokens.append(Tok("comment", text, line))
-			            line += text.count("\n")
-			            i = j
-			            continue
-			        if c == '"' or c == "'":
-			            quote = c
-			            j = i + 1
-			            buf = []
-			            while j < n:
-			                if s[j] == "\\":
-			                    buf.append(s[j : j + 2])
-			                    j += 2
-			                    continue
-			                if s[j] == quote:
-			                    break
-			                buf.append(s[j])
-			                j += 1
-			            tokens.append(Tok("string", (quote, "".join(buf)), line))
-			            i = j + 1
-			            continue
-			        if c in "{}[]:,":
-			            tokens.append(Tok("punct", c, line))
-			            i += 1
-			            continue
-			        j = i
-			        while j < n and s[j] not in " \t\r\n" and s[j] not in "{}[]:,/\"'":
-			            j += 1
-			        tokens.append(Tok("word", s[i:j], line))
-			        i = j
-			    return tokens
-
-
-			def decode_string(quote, raw):
-			    out = []
-			    i = 0
-			    n = len(raw)
-			    while i < n:
-			        ch = raw[i]
-			        if ch == "\\" and i + 1 < n:
-			            nxt = raw[i + 1]
-			            simple = {"n": "\n", "t": "\t", "r": "\r", "b": "\b", "f": "\f", "v": "\v", "0": "\0"}
-			            if nxt in simple:
-			                out.append(simple[nxt])
-			                i += 2
-			            elif nxt == "u":
-			                out.append(chr(int(raw[i + 2 : i + 6], 16)))
-			                i += 6
-			            elif nxt == "x":
-			                out.append(chr(int(raw[i + 2 : i + 4], 16)))
-			                i += 4
-			            elif nxt == "\n":
-			                i += 2
-			            else:
-			                out.append(nxt)
-			                i += 2
-			            continue
-			        out.append(ch)
-			        i += 1
-			    return "".join(out)
-
-
-			def normalize_word(word):
-			    if word in ("true", "false", "null"):
-			        return word
-			    stripped = word.lstrip("+")
-			    if stripped.lstrip("-") in ("Infinity", "NaN"):
-			        return stripped
-			    low = stripped.lower()
-			    if low.startswith("0x") or low.startswith("-0x"):
-			        return str(int(stripped, 16))
-			    try:
-			        return str(int(stripped))
-			    except ValueError:
-			        pass
-			    try:
-			        float(stripped)
-			        return stripped
-			    except ValueError:
-			        return json.dumps(word)
-
-
-			class Parser:
-			    def __init__(self, tokens):
-			        self.toks = tokens
-			        self.pos = 0
-
-			    def at(self):
-			        return self.toks[self.pos] if self.pos < len(self.toks) else None
-
-			    def comments(self):
-			        out = []
-			        while self.pos < len(self.toks) and self.toks[self.pos].kind == "comment":
-			            out.append(self.toks[self.pos].value)
-			            self.pos += 1
-			        return out
-
-			    def parse_value(self):
-			        tok = self.toks[self.pos]
-			        if tok.kind == "punct" and tok.value == "{":
-			            return self.parse_object()
-			        if tok.kind == "punct" and tok.value == "[":
-			            return self.parse_array()
-			        if tok.kind == "string":
-			            self.pos += 1
-			            q, raw = tok.value
-			            return ("scalar", json.dumps(decode_string(q, raw)))
-			        if tok.kind == "word":
-			            self.pos += 1
-			            return ("scalar", normalize_word(tok.value))
-			        raise ValueError("unexpected token: %r" % (tok.value,))
-
-			    def consume_tail(self, value_line):
-			        # optional trailing comment + comma in either order
-			        trailing = None
-			        if (
-			            self.pos < len(self.toks)
-			            and self.toks[self.pos].kind == "comment"
-			            and self.toks[self.pos].line == value_line
-			        ):
-			            trailing = self.toks[self.pos].value
-			            self.pos += 1
-			        if self.pos < len(self.toks) and self.toks[self.pos].kind == "punct" and self.toks[self.pos].value == ",":
-			            comma_line = self.toks[self.pos].line
-			            self.pos += 1
-			            if (
-			                trailing is None
-			                and self.pos < len(self.toks)
-			                and self.toks[self.pos].kind == "comment"
-			                and self.toks[self.pos].line == comma_line
-			            ):
-			                trailing = self.toks[self.pos].value
-			                self.pos += 1
-			        return trailing
-
-			    def parse_object(self):
-			        self.pos += 1  # '{'
-			        members = []
-			        while True:
-			            leading = self.comments()
-			            tok = self.toks[self.pos]
-			            if tok.kind == "punct" and tok.value == "}":
-			                self.pos += 1
-			                return ("object", members, leading)
-			            if tok.kind == "string":
-			                q, raw = tok.value
-			                key = decode_string(q, raw)
-			            elif tok.kind == "word":
-			                key = tok.value
-			            else:
-			                raise ValueError("expected key, got %r" % (tok.value,))
-			            self.pos += 1
-			            leading += self.comments()
-			            assert self.toks[self.pos].value == ":", "expected colon"
-			            self.pos += 1
-			            leading += self.comments()
-			            value = self.parse_value()
-			            value_line = self.toks[self.pos - 1].line
-			            trailing = self.consume_tail(value_line)
-			            members.append({"leading": leading, "key": key, "value": value, "trailing": trailing})
-
-			    def parse_array(self):
-			        self.pos += 1  # '['
-			        elems = []
-			        while True:
-			            leading = self.comments()
-			            tok = self.toks[self.pos]
-			            if tok.kind == "punct" and tok.value == "]":
-			                self.pos += 1
-			                return ("array", elems, leading)
-			            value = self.parse_value()
-			            value_line = self.toks[self.pos - 1].line
-			            trailing = self.consume_tail(value_line)
-			            elems.append({"leading": leading, "value": value, "trailing": trailing})
-
-
-			def compact_json(node):
-			    kind = node[0]
-			    if kind == "scalar":
-			        return node[1]
-			    if kind == "object":
-			        members, dangling = node[1], node[2]
-			        if dangling:
-			            return None
-			        items = []
-			        for m in members:
-			            if m["leading"] or m["trailing"]:
-			                return None
-			            v = compact_json(m["value"])
-			            if v is None:
-			                return None
-			            items.append((m["key"], v))
-			        if not items:
-			            return "{}"
-			        items.sort(key=lambda x: x[0])
-			        return "{" + ", ".join(json.dumps(k) + ": " + v for k, v in items) + "}"
-			    members, dangling = node[1], node[2]
-			    if dangling:
-			        return None
-			    parts = []
-			    for e in members:
-			        if e["leading"] or e["trailing"]:
-			            return None
-			        v = compact_json(e["value"])
-			        if v is None:
-			            return None
-			        parts.append(v)
-			    if not parts:
-			        return "[]"
-			    return "[" + ", ".join(parts) + "]"
-
-
-			def align_json(node, indent=0):
-			    ind = "  " * indent
-			    current_col = len(ind)
-			    kind = node[0]
-			    if kind == "scalar":
-			        return node[1]
-
-			    if kind == "object":
-			        members, dangling = node[1], node[2]
-			        if not members and not dangling:
-			            return "{}"
-			        compact = compact_json(node)
-			        if compact is not None and "\n" not in compact and current_col + len(compact) < LINE_WIDTH:
-			            return compact
-			        sm = sorted(members, key=lambda m: m["key"])
-			        max_len = max(len(json.dumps(m["key"])) for m in sm) if sm else 0
-			        lines = ["{"]
-			        for i, m in enumerate(sm):
-			            for c in m["leading"]:
-			                lines.append(f"{ind}  {c}")
-			            key_str = json.dumps(m["key"])
-			            value_str = align_json(m["value"], indent + 1)
-			            padding = " " * (max_len - len(key_str))
-			            comma = "," if i < len(sm) - 1 else ""
-			            trail = f"  {m['trailing']}" if m["trailing"] else ""
-			            lines.append(f"{ind}  {key_str}{padding}: {value_str}{comma}{trail}")
-			        for c in dangling:
-			            lines.append(f"{ind}  {c}")
-			        lines.append(f"{ind}}}")
-			        return "\n".join(lines)
-
-			    elems, dangling = node[1], node[2]
-			    if not elems and not dangling:
-			        return "[]"
-			    compact = compact_json(node)
-			    if compact is not None and "\n" not in compact and current_col + len(compact) < LINE_WIDTH:
-			        return compact
-			    has_comments = bool(dangling) or any(e["leading"] or e["trailing"] for e in elems)
-			    all_scalar = all(e["value"][0] == "scalar" for e in elems)
-			    if all_scalar and not has_comments:
-			        inner_ind = ind + "  "
-			        lines = ["["]
-			        current_line = inner_ind
-			        for i, e in enumerate(elems):
-			            entry = e["value"][1] + (", " if i < len(elems) - 1 else "")
-			            if current_line == inner_ind:
-			                current_line += entry
-			            elif len(current_line) + len(entry) <= LINE_WIDTH:
-			                current_line += entry
-			            else:
-			                lines.append(current_line.rstrip())
-			                current_line = inner_ind + entry
-			        if current_line.strip():
-			            lines.append(current_line.rstrip())
-			        lines.append(f"{ind}]")
-			        return "\n".join(lines)
-			    lines = ["["]
-			    for i, e in enumerate(elems):
-			        for c in e["leading"]:
-			            lines.append(f"{ind}  {c}")
-			        value_str = align_json(e["value"], indent + 1)
-			        comma = "," if i < len(elems) - 1 else ""
-			        trail = f"  {e['trailing']}" if e["trailing"] else ""
-			        lines.append(f"{ind}  {value_str}{comma}{trail}")
-			    for c in dangling:
-			        lines.append(f"{ind}  {c}")
-			    lines.append(f"{ind}]")
-			    return "\n".join(lines)
-
-
-			with open(sys.argv[1], "r") as f:
-			    text = f.read()
-
-			parser = Parser(tokenize(text))
-			header = parser.comments()
-			root = parser.parse_value()
-			footer = parser.comments()
-
-			out = list(header)
-			out.append(align_json(root, 0))
-			out.extend(footer)
-
-			with open(sys.argv[1], "w") as f:
-			    f.write("\n".join(out) + "\n")
-		PYEOF
+		# Heavy lifting lives in ~/.local/bin/json_formatter.py (copied by setup).
+		python3 "$HOME/.local/bin/json_formatter.py" "$file" "$line_width" 2>/dev/null || {
 			log "Failed to parse $file, falling back to jq"
 			if command -v jq &>/dev/null; then
 				jq -S '.' "$file" >"$file.tmp" && mv "$file.tmp" "$file"

--- a/dotfiles/.profile
+++ b/dotfiles/.profile
@@ -26,14 +26,16 @@ if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
 
-IFS=:
-unique_paths=()
-for path in $PATH; do
-    if [[ ! "${unique_paths[*]}" =~ ${path} ]]; then
-        unique_paths+=("$path")
+# Deduplicate PATH, preserving order (exact match, not substring)
+declare -A _seen_paths
+_new_path=()
+IFS=: read -ra _path_parts <<<"$PATH"
+for _p in "${_path_parts[@]}"; do
+    if [ -n "$_p" ] && [ -z "${_seen_paths[$_p]:-}" ]; then
+        _seen_paths["$_p"]=1
+        _new_path+=("$_p")
     fi
 done
-IFS=$' \t\n'
-
-new_path=$(IFS=:; echo "${unique_paths[*]}")
-export PATH="$new_path"
+IFS=:
+export PATH="${_new_path[*]}"
+unset IFS _seen_paths _new_path _path_parts _p

--- a/dotfiles/bin/json_formatter.py
+++ b/dotfiles/bin/json_formatter.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""In-place JSON/JSON5 reformatter.
+
+Sorts object keys, aligns colons, packs scalar arrays wide, and PRESERVES
+comments. Parses json and json5 natively (no json5->json pre-pass), so //
+and /* */ comments survive on both.
+
+Usage: json_formatter.py <file> [line_width]
+"""
+
+import json
+import sys
+
+LINE_WIDTH = int(sys.argv[2]) if len(sys.argv) > 2 else 80
+
+
+class Tok:
+    __slots__ = ("kind", "value", "line")
+
+    def __init__(self, kind, value, line):
+        self.kind = kind
+        self.value = value
+        self.line = line
+
+
+def tokenize(s):
+    tokens = []
+    i = 0
+    n = len(s)
+    line = 0
+    while i < n:
+        c = s[i]
+        if c == "\n":
+            line += 1
+            i += 1
+            continue
+        if c in " \t\r":
+            i += 1
+            continue
+        if c == "/" and i + 1 < n and s[i + 1] == "/":
+            j = i + 2
+            while j < n and s[j] != "\n":
+                j += 1
+            tokens.append(Tok("comment", s[i:j].rstrip(), line))
+            i = j
+            continue
+        if c == "/" and i + 1 < n and s[i + 1] == "*":
+            j = i + 2
+            while j < n and not (s[j] == "*" and j + 1 < n and s[j + 1] == "/"):
+                j += 1
+            j = min(j + 2, n)
+            text = s[i:j]
+            tokens.append(Tok("comment", text, line))
+            line += text.count("\n")
+            i = j
+            continue
+        if c == '"' or c == "'":
+            quote = c
+            j = i + 1
+            buf = []
+            while j < n:
+                if s[j] == "\\":
+                    buf.append(s[j : j + 2])
+                    j += 2
+                    continue
+                if s[j] == quote:
+                    break
+                buf.append(s[j])
+                j += 1
+            tokens.append(Tok("string", (quote, "".join(buf)), line))
+            i = j + 1
+            continue
+        if c in "{}[]:,":
+            tokens.append(Tok("punct", c, line))
+            i += 1
+            continue
+        j = i
+        while j < n and s[j] not in " \t\r\n" and s[j] not in "{}[]:,/\"'":
+            j += 1
+        tokens.append(Tok("word", s[i:j], line))
+        i = j
+    return tokens
+
+
+def decode_string(quote, raw):
+    out = []
+    i = 0
+    n = len(raw)
+    while i < n:
+        ch = raw[i]
+        if ch == "\\" and i + 1 < n:
+            nxt = raw[i + 1]
+            simple = {"n": "\n", "t": "\t", "r": "\r", "b": "\b", "f": "\f", "v": "\v", "0": "\0"}
+            if nxt in simple:
+                out.append(simple[nxt])
+                i += 2
+            elif nxt == "u":
+                out.append(chr(int(raw[i + 2 : i + 6], 16)))
+                i += 6
+            elif nxt == "x":
+                out.append(chr(int(raw[i + 2 : i + 4], 16)))
+                i += 4
+            elif nxt == "\n":
+                i += 2
+            else:
+                out.append(nxt)
+                i += 2
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+def normalize_word(word):
+    if word in ("true", "false", "null"):
+        return word
+    stripped = word.lstrip("+")
+    if stripped.lstrip("-") in ("Infinity", "NaN"):
+        return stripped
+    low = stripped.lower()
+    if low.startswith("0x") or low.startswith("-0x"):
+        return str(int(stripped, 16))
+    try:
+        return str(int(stripped))
+    except ValueError:
+        pass
+    try:
+        float(stripped)
+        return stripped
+    except ValueError:
+        return json.dumps(word)
+
+
+class Parser:
+    def __init__(self, tokens):
+        self.toks = tokens
+        self.pos = 0
+
+    def at(self):
+        return self.toks[self.pos] if self.pos < len(self.toks) else None
+
+    def comments(self):
+        out = []
+        while self.pos < len(self.toks) and self.toks[self.pos].kind == "comment":
+            out.append(self.toks[self.pos].value)
+            self.pos += 1
+        return out
+
+    def parse_value(self):
+        tok = self.toks[self.pos]
+        if tok.kind == "punct" and tok.value == "{":
+            return self.parse_object()
+        if tok.kind == "punct" and tok.value == "[":
+            return self.parse_array()
+        if tok.kind == "string":
+            self.pos += 1
+            q, raw = tok.value
+            return ("scalar", json.dumps(decode_string(q, raw)))
+        if tok.kind == "word":
+            self.pos += 1
+            return ("scalar", normalize_word(tok.value))
+        raise ValueError("unexpected token: %r" % (tok.value,))
+
+    def consume_tail(self, value_line):
+        # optional trailing comment + comma in either order
+        trailing = None
+        if (
+            self.pos < len(self.toks)
+            and self.toks[self.pos].kind == "comment"
+            and self.toks[self.pos].line == value_line
+        ):
+            trailing = self.toks[self.pos].value
+            self.pos += 1
+        if self.pos < len(self.toks) and self.toks[self.pos].kind == "punct" and self.toks[self.pos].value == ",":
+            comma_line = self.toks[self.pos].line
+            self.pos += 1
+            if (
+                trailing is None
+                and self.pos < len(self.toks)
+                and self.toks[self.pos].kind == "comment"
+                and self.toks[self.pos].line == comma_line
+            ):
+                trailing = self.toks[self.pos].value
+                self.pos += 1
+        return trailing
+
+    def parse_object(self):
+        self.pos += 1  # '{'
+        members = []
+        while True:
+            leading = self.comments()
+            tok = self.toks[self.pos]
+            if tok.kind == "punct" and tok.value == "}":
+                self.pos += 1
+                return ("object", members, leading)
+            if tok.kind == "string":
+                q, raw = tok.value
+                key = decode_string(q, raw)
+            elif tok.kind == "word":
+                key = tok.value
+            else:
+                raise ValueError("expected key, got %r" % (tok.value,))
+            self.pos += 1
+            leading += self.comments()
+            assert self.toks[self.pos].value == ":", "expected colon"
+            self.pos += 1
+            leading += self.comments()
+            value = self.parse_value()
+            value_line = self.toks[self.pos - 1].line
+            trailing = self.consume_tail(value_line)
+            members.append({"leading": leading, "key": key, "value": value, "trailing": trailing})
+
+    def parse_array(self):
+        self.pos += 1  # '['
+        elems = []
+        while True:
+            leading = self.comments()
+            tok = self.toks[self.pos]
+            if tok.kind == "punct" and tok.value == "]":
+                self.pos += 1
+                return ("array", elems, leading)
+            value = self.parse_value()
+            value_line = self.toks[self.pos - 1].line
+            trailing = self.consume_tail(value_line)
+            elems.append({"leading": leading, "value": value, "trailing": trailing})
+
+
+def compact_json(node):
+    kind = node[0]
+    if kind == "scalar":
+        return node[1]
+    if kind == "object":
+        members, dangling = node[1], node[2]
+        if dangling:
+            return None
+        items = []
+        for m in members:
+            if m["leading"] or m["trailing"]:
+                return None
+            v = compact_json(m["value"])
+            if v is None:
+                return None
+            items.append((m["key"], v))
+        if not items:
+            return "{}"
+        items.sort(key=lambda x: x[0])
+        return "{" + ", ".join(json.dumps(k) + ": " + v for k, v in items) + "}"
+    members, dangling = node[1], node[2]
+    if dangling:
+        return None
+    parts = []
+    for e in members:
+        if e["leading"] or e["trailing"]:
+            return None
+        v = compact_json(e["value"])
+        if v is None:
+            return None
+        parts.append(v)
+    if not parts:
+        return "[]"
+    return "[" + ", ".join(parts) + "]"
+
+
+def align_json(node, indent=0):
+    ind = "  " * indent
+    current_col = len(ind)
+    kind = node[0]
+    if kind == "scalar":
+        return node[1]
+
+    if kind == "object":
+        members, dangling = node[1], node[2]
+        if not members and not dangling:
+            return "{}"
+        compact = compact_json(node)
+        if compact is not None and "\n" not in compact and current_col + len(compact) < LINE_WIDTH:
+            return compact
+        sm = sorted(members, key=lambda m: m["key"])
+        max_len = max(len(json.dumps(m["key"])) for m in sm) if sm else 0
+        lines = ["{"]
+        for i, m in enumerate(sm):
+            for c in m["leading"]:
+                lines.append(f"{ind}  {c}")
+            key_str = json.dumps(m["key"])
+            value_str = align_json(m["value"], indent + 1)
+            padding = " " * (max_len - len(key_str))
+            comma = "," if i < len(sm) - 1 else ""
+            trail = f"  {m['trailing']}" if m["trailing"] else ""
+            lines.append(f"{ind}  {key_str}{padding}: {value_str}{comma}{trail}")
+        for c in dangling:
+            lines.append(f"{ind}  {c}")
+        lines.append(f"{ind}}}")
+        return "\n".join(lines)
+
+    elems, dangling = node[1], node[2]
+    if not elems and not dangling:
+        return "[]"
+    compact = compact_json(node)
+    if compact is not None and "\n" not in compact and current_col + len(compact) < LINE_WIDTH:
+        return compact
+    has_comments = bool(dangling) or any(e["leading"] or e["trailing"] for e in elems)
+    all_scalar = all(e["value"][0] == "scalar" for e in elems)
+    if all_scalar and not has_comments:
+        inner_ind = ind + "  "
+        lines = ["["]
+        current_line = inner_ind
+        for i, e in enumerate(elems):
+            entry = e["value"][1] + (", " if i < len(elems) - 1 else "")
+            if current_line == inner_ind:
+                current_line += entry
+            elif len(current_line) + len(entry) <= LINE_WIDTH:
+                current_line += entry
+            else:
+                lines.append(current_line.rstrip())
+                current_line = inner_ind + entry
+        if current_line.strip():
+            lines.append(current_line.rstrip())
+        lines.append(f"{ind}]")
+        return "\n".join(lines)
+    lines = ["["]
+    for i, e in enumerate(elems):
+        for c in e["leading"]:
+            lines.append(f"{ind}  {c}")
+        value_str = align_json(e["value"], indent + 1)
+        comma = "," if i < len(elems) - 1 else ""
+        trail = f"  {e['trailing']}" if e["trailing"] else ""
+        lines.append(f"{ind}  {value_str}{comma}{trail}")
+    for c in dangling:
+        lines.append(f"{ind}  {c}")
+    lines.append(f"{ind}]")
+    return "\n".join(lines)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: json_formatter.py <file> [line_width]", file=sys.stderr)
+        return 1
+
+    with open(sys.argv[1], "r") as f:
+        text = f.read()
+
+    parser = Parser(tokenize(text))
+    header = parser.comments()
+    root = parser.parse_value()
+    footer = parser.comments()
+
+    out = list(header)
+    out.append(align_json(root, 0))
+    out.extend(footer)
+
+    with open(sys.argv[1], "w") as f:
+        f.write("\n".join(out) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dotfiles/starship.toml
+++ b/dotfiles/starship.toml
@@ -14,6 +14,10 @@ $cmd_duration\
 $line_break\
 $character"""
 
+# Cap any per-module command (python/rust/go/terraform version lookups, etc.)
+# so a slow toolchain binary can never stall the prompt.
+command_timeout = 500
+
 [username]
 format = "[$user]($style)"
 style_user = "bold blue"

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -19,6 +19,17 @@ ensure_directory() {
 	cd $PROFILE_DIR
 }
 
+# Evaluate the Homebrew shellenv matching the current architecture.
+# Apple Silicon native uses /opt/homebrew, Rosetta/Intel uses /usr/local;
+# fall back to the other prefix if the preferred one isn't present.
+brew_shellenv() {
+	if [ "$(uname -m)" = "arm64" ]; then
+		eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null || /usr/local/bin/brew shellenv 2>/dev/null || true)"
+	else
+		eval "$(/usr/local/bin/brew shellenv 2>/dev/null || /opt/homebrew/bin/brew shellenv 2>/dev/null || true)"
+	fi
+}
+
 collect_user_input() {
 	# Gather all interactive input upfront so the rest of the setup is unattended
 	GIT_USER_NAME=$(git config --global user.name 2>/dev/null) || GIT_USER_NAME=""
@@ -64,7 +75,6 @@ set_git_config() {
 	print_function_name
 	git config --global core.autocrlf false
 	git config --global pull.rebase false
-	git config --global http.sslVerify false
 	git config --global diff.tool bc3
 	git config --global color.branch auto
 	git config --global color.diff auto
@@ -182,32 +192,10 @@ install_pyenv() {
 			fi
 		fi
 	else
-		# Install the pinned default version exactly as specified
+		# Install the pinned default version exactly as specified.
+		# Only one version is installed on purpose — extra minor versions slow
+		# down pyenv shim resolution (and the prompt) without much benefit.
 		pyenv install -s "$DEFAULT_PYTHON_VERSION"
-
-		# Track the latest patch for the older minor versions
-		for pyver in 3.13 3.12 3.11; do
-			# Find the latest available patch for this major.minor
-			local latest
-			latest=$(pyenv install --list | tr -d ' ' | grep -E "^${pyver}\.[0-9]+$" | sort -V | tail -1)
-			if [ -z "$latest" ]; then
-				log "No available patch found for $pyver, skipping"
-				continue
-			fi
-			# Check what's already installed for this major.minor
-			local installed
-			installed=$(pyenv versions --bare | grep -E "^${pyver}\.[0-9]+$" | sort -V | tail -1)
-			if [ "$installed" = "$latest" ]; then
-				log "Python $latest already installed, skipping"
-				continue
-			fi
-			if [ -n "$installed" ]; then
-				log "Upgrading Python $pyver: $installed -> $latest"
-			else
-				log "Installing Python $latest"
-			fi
-			pyenv install -f "$latest"
-		done
 	fi
 	pyenv global "$DEFAULT_PYTHON_VERSION"
 

--- a/tools/setup_macos.sh
+++ b/tools/setup_macos.sh
@@ -7,13 +7,6 @@ export PROJECT_ROOT=$HOME/profile
 export PATH="/usr/local/bin:$PATH"
 export PATH="/usr/local/sbin:$PATH"
 export PATH="$HOME/.local/bin:$PATH"
-# Use the Homebrew matching the current architecture
-# (Apple Silicon native uses /opt/homebrew, Rosetta/Intel uses /usr/local)
-if [ "$(uname -m)" = "arm64" ]; then
-	eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null || /usr/local/bin/brew shellenv 2>/dev/null || true)"
-else
-	eval "$(/usr/local/bin/brew shellenv 2>/dev/null || /opt/homebrew/bin/brew shellenv 2>/dev/null || true)"
-fi
 export PROFILE_DIR=$(pwd)
 export ARCHITECTURE=$(uname -m)
 set -e
@@ -24,6 +17,9 @@ sudo -v
 source "$PROFILE_DIR/tools/common.sh"
 trap 'handle_error $LINENO' ERR
 
+# Use the Homebrew matching the current architecture
+brew_shellenv
+
 copy_dotfiles() {
 	print_function_name
 	mkdir -p "$HOME/.config"
@@ -33,6 +29,13 @@ copy_dotfiles() {
 	cp "$PROFILE_DIR/dotfiles/.bashrc" "$HOME/.bashrc"
 	cp "$PROFILE_DIR/dotfiles/.prettierrc" "$HOME/.prettierrc"
 	cp "$PROFILE_DIR/dotfiles/.bash_aliases" "$HOME/.bash_aliases"
+
+	# Helper scripts that .bash_aliases shells out to (keeps the sourced
+	# .bash_aliases small/fast). Same path is used on macOS and Linux.
+	mkdir -p "$HOME/.local/bin"
+	cp "$PROFILE_DIR/dotfiles/bin/json_formatter.py" "$HOME/.local/bin/json_formatter.py"
+	chmod +x "$HOME/.local/bin/json_formatter.py"
+
 	copy_btop_config
 
 	# Ghostty config (shared between macOS and Linux)
@@ -98,11 +101,7 @@ install_homebrew() {
 
 	# Re-evaluate brew shellenv to ensure PATH includes Homebrew for the
 	# rest of this script (covers both fresh install and existing install)
-	if [ "$(uname -m)" = "arm64" ]; then
-		eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null || /usr/local/bin/brew shellenv 2>/dev/null || true)"
-	else
-		eval "$(/usr/local/bin/brew shellenv 2>/dev/null || /opt/homebrew/bin/brew shellenv 2>/dev/null || true)"
-	fi
+	brew_shellenv
 
 	# Set HOMEBREW_NO_AUTO_UPDATE to prevent brew from running git updates
 	# during individual installs (we handle updates explicitly)
@@ -215,7 +214,6 @@ install_rust() {
 	# rustup is installed via Homebrew
 	rustup-init -y --default-toolchain stable
 	source "$HOME/.cargo/env"
-	rustup update stable
 	rustup install nightly
 	rustup component add rustfmt clippy
 	rustup update stable

--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -30,6 +30,13 @@ copy_dotfiles() {
 	cp $PROFILE_DIR/dotfiles/.bashrc $HOME/.bashrc
 	cp $PROFILE_DIR/dotfiles/.prettierrc $HOME/.prettierrc
 	cp $PROFILE_DIR/dotfiles/.bash_aliases $HOME/.bash_aliases
+
+	# Helper scripts that .bash_aliases shells out to (keeps the sourced
+	# .bash_aliases small/fast). Same path is used on macOS and Linux.
+	mkdir -p "$HOME/.local/bin"
+	cp "$PROFILE_DIR/dotfiles/bin/json_formatter.py" "$HOME/.local/bin/json_formatter.py"
+	chmod +x "$HOME/.local/bin/json_formatter.py"
+
 	copy_btop_config
 	# Case-insensitive tab completion (idempotent)
 	if ! grep -q 'completion-ignore-case' /etc/inputrc 2>/dev/null; then
@@ -372,7 +379,6 @@ install_rust() {
 	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable
 	source ~/.cargo/env
 	source ~/.bashrc 2>/dev/null || true
-	rustup update stable
 	rustup install nightly
 	# cargo install diesel_cli --no-default-features --features postgres
 	rustup component add rustfmt clippy


### PR DESCRIPTION
## Summary

Targets slow interactive-shell startup and trims the dotfiles, per review of the setup scripts + `.bashrc`/`.bash_aliases`/`starship.toml`.

### Startup speed
- **starship**: add `command_timeout = 500` so a slow toolchain version lookup (python/rust/go/terraform) can never stall the prompt.
- **pyenv**: install only the pinned `DEFAULT_PYTHON_VERSION` on Linux instead of *also* building the latest patch of 3.13/3.12/3.11. Fewer shims → faster `pyenv` resolution (and prompt), and a much quicker `setup`.
- **Slim `.bash_aliases`**: extracted the ~340-line embedded Python JSON formatter into `dotfiles/bin/json_formatter.py`, copied to `~/.local/bin` on **both macOS and Linux** by `copy_dotfiles`. `.bash_aliases` now just shells out to it, so far less is parsed on every interactive shell (file shrinks ~340 lines).

### Correctness / robustness
- **Drop `alias grep='rg'`**: the alias was being baked into every later function that calls bare `grep` (alias expansion happens at function-definition time), which is the class of bug the recent `_fmt_files` commits fought. `grep` is now real `grep --color=auto -E`; use `rg` explicitly for ripgrep.
- **Fix fragile PATH/PYTHONPATH dedup** in `.profile` and `pypath()`: the old `[[ ... =~ $path ]]` did a regex *substring* match, so `/usr/bin` would suppress `/usr/bin/foo`. Now exact-match via an associative array, order preserved.
- **Remove `git config --global http.sslVerify false`**: it disabled TLS verification for all git operations machine-wide.
- **Factor duplicated brew `shellenv` arch-detection** into a `brew_shellenv()` helper in `common.sh`.
- **Remove the redundant second `rustup update stable`** on macOS and Ubuntu.

Not included (left per request): the `setup_entry.sh` `git reset --hard` guard.

## Testing
- `json_formatter.py` round-trips json5 (comments preserved, keys sorted, scalar arrays packed) and falls back to `jq` on parse failure.
- `bash -n` passes on all changed scripts; `shfmt -d` clean.
- `pypath`/`.profile` dedup verified: exact-match, order preserved, `/usr/bin/foo` no longer dropped.
- `.bash_aliases` sources cleanly; `grep` resolves to real grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Speed up interactive shell startup and improve robustness of environment setup and tooling across macOS and Linux.

New Features:
- Add a standalone json_formatter.py helper script for JSON/JSON5 formatting and expose it via .bash_aliases.
- Introduce a reusable brew_shellenv helper to select the appropriate Homebrew installation per architecture.
- Configure a global command_timeout in starship to cap slow prompt module commands.

Bug Fixes:
- Ensure grep refers to real grep with color and extended regex instead of conditionally aliasing to rg, avoiding unexpected behavior in shell functions.
- Fix PATH and PYTHONPATH de-duplication to perform exact, order-preserving matches instead of substring-based filtering that could drop valid entries.
- Remove the global git http.sslVerify=false setting to restore TLS verification for git operations.

Enhancements:
- Slim down .bash_aliases by moving heavy embedded Python logic into an external script to reduce shell parse overhead on startup.
- Simplify pyenv installation on Linux to only install the pinned default Python version, reducing shims and improving performance.
- Avoid redundant rustup update stable invocations in macOS and Ubuntu setup scripts.