### PR TITLE
Fix Mac setup: one-time sudo prompt + brew bundle appcast failure

### DIFF
--- a/tools/common.sh
+++ b/tools/common.sh
@@ -7,6 +7,34 @@ handle_error() {
 	echo "An error occurred on line $1"
 }
 
+# Prime the sudo timestamp once, then keep it warm in the background so a long
+# unattended install only prompts for the password a single time.
+# - Idempotent: a second call is a no-op while a loop is already running.
+# - set -e / pipefail safe: the priming `sudo -v` is guarded with `|| return`,
+#   and the background loop's commands can't abort the parent shell.
+# - The loop exits on its own once the parent script ($$) is gone, is killed by
+#   the EXIT trap on error/early-exit paths, and is killed explicitly by
+#   exit_script before its `exec bash -l` (which would otherwise bypass EXIT).
+SUDO_KEEPALIVE_PID=""
+keep_sudo_alive() {
+	# Already running? Do nothing.
+	if [ -n "$SUDO_KEEPALIVE_PID" ] && kill -0 "$SUDO_KEEPALIVE_PID" 2>/dev/null; then
+		return 0
+	fi
+	# Prompt for the password once (non-fatal under set -e if the user aborts).
+	sudo -v || return 1
+	# Refresh the timestamp every 60s until this script's PID disappears.
+	local parent_pid=$$
+	while true; do
+		sudo -n true 2>/dev/null || true
+		sleep 60
+		kill -0 "$parent_pid" 2>/dev/null || exit 0
+	done &
+	SUDO_KEEPALIVE_PID=$!
+	# Reap the loop when the script exits (without clobbering the ERR trap).
+	trap 'kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true' EXIT
+}
+
 print_function_name() {
 	log "\033[1;36mExecuting function: ${FUNCNAME[1]}\033[0m"
 }
@@ -233,6 +261,9 @@ install_pyenv() {
 
 exit_script() {
 	print_function_name
+	# Stop the sudo keepalive explicitly: the `exec bash -l` below replaces this
+	# process, so the EXIT trap would never fire to reap it otherwise.
+	[ -n "$SUDO_KEEPALIVE_PID" ] && kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
 	ensure_directory
 	if [ ${#failed_functions[@]} -eq 0 ]; then
 		echo "==============================="

--- a/tools/setup_macos.sh
+++ b/tools/setup_macos.sh
@@ -12,10 +12,11 @@ export ARCHITECTURE=$(uname -m)
 set -e
 set -o pipefail
 
-sudo -v
-
 source "$PROFILE_DIR/tools/common.sh"
 trap 'handle_error $LINENO' ERR
+
+# Prompt for sudo once, then keep the timestamp warm for the whole install.
+keep_sudo_alive
 
 # Use the Homebrew matching the current architecture
 brew_shellenv
@@ -123,11 +124,24 @@ install_packages() {
 		fi
 	done
 
-	# Homebrew uses the API by default now; local taps waste space
+	# Homebrew uses the API by default now; local taps waste space and, worse,
+	# their stale cask .rb sources shadow the live API casks. A leftover
+	# definition referencing the long-removed `appcast` stanza (removed in
+	# brew 4.3) makes a cask "unreadable" and aborts the whole `brew bundle`.
+	# Force-untap and delete the leftover tap checkouts so the API casks win.
+	local brew_repo
+	brew_repo="$(brew --repository)"
 	for tap in homebrew/core homebrew/cask; do
 		if brew tap | grep -q "^${tap}$"; then
 			log "Removing unnecessary tap: $tap"
-			brew untap "$tap" 2>/dev/null || true
+			brew untap --force "$tap" 2>/dev/null || true
+		fi
+		# Remove any leftover on-disk tap checkout even if `brew tap` no longer
+		# lists it (untap can leave the directory behind).
+		local tap_dir="$brew_repo/Library/Taps/${tap%/*}/homebrew-${tap#*/}"
+		if [ -d "$tap_dir" ]; then
+			log "Removing leftover tap directory: $tap_dir"
+			rm -rf "$tap_dir"
 		fi
 	done
 
@@ -150,11 +164,31 @@ install_packages() {
 		fi
 	done
 
+	# Purge stale cached cask source (the `.rb` Homebrew caches per-install).
+	# When present these are loaded via FromInstalledPathLoader and can still
+	# reference the removed `appcast` stanza, shadowing the current API cask
+	# (e.g. "Cask 'google-chrome' is unreadable: undefined method 'appcast'").
+	# Deleting them is safe: brew re-reads the cask from the API on next run.
+	if [ -d "$caskroom" ]; then
+		log "Clearing stale cached cask sources (.rb) under Caskroom..."
+		find "$caskroom" -path '*/.metadata/*' -name '*.rb' -delete 2>/dev/null || true
+	fi
+	# Drop any stale downloaded cask metadata from the cache as well.
+	# Guard the path so an empty `brew --cache` can never expand to `/Cask`.
+	local brew_cache
+	brew_cache="$(brew --cache 2>/dev/null)"
+	[ -n "$brew_cache" ] && rm -rf "${brew_cache:?}/Cask" 2>/dev/null || true
+
 	log "Updating Homebrew..."
-	# brew update can fail on stale taps — not critical
+	# Reset local repo state so the JSON API (not stale local taps) is the
+	# source of truth, then update. Both are best-effort — non-fatal on error.
+	brew update-reset || log "Warning: brew update-reset had errors, continuing..."
 	brew update || log "Warning: brew update had errors, continuing..."
 	log "Installing packages from Brewfile..."
-	brew bundle --file="$PROFILE_DIR/tools/Brewfile"
+	# Resilience: one unreadable cask must not abort the whole bundle. The
+	# metadata purge above plus update-reset make a transiently-unreadable cask
+	# self-heal; `|| log` lets the rest of setup continue if one entry fails.
+	brew bundle --file="$PROFILE_DIR/tools/Brewfile" || log "Warning: brew bundle reported errors (likely a stale/unreadable cask); continuing..."
 	brew upgrade --greedy
 	brew cleanup
 

--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -15,6 +15,9 @@ set -o pipefail
 source "$PROFILE_DIR/tools/common.sh"
 trap 'handle_error $LINENO' ERR
 
+# Prompt for sudo once, then keep the timestamp warm for the whole install.
+keep_sudo_alive
+
 copy_dotfiles() {
 	print_function_name
 	mkdir -p $HOME/.config/terminator


### PR DESCRIPTION
Fixes two bugs hit on a fresh macOS `source setup_entry.sh` run.

## 1. Repeated sudo password prompts
The scripts ran `sudo -v` once and never refreshed the timestamp, so after the ~5-minute sudo timeout every later `sudo` call (`xcodebuild -license accept`, `chsh`, the Tailscale wrapper, brew cask steps, …) re-prompted. `setup_ubuntu.sh` never primed sudo at all. The keepalive pattern documented in `CLAUDE.md` was never actually implemented.

- New `keep_sudo_alive()` helper in `common.sh`: prompts once, then refreshes every 60s in the background.
- Idempotent (won't spawn a second loop), `set -e`/`pipefail` safe, reaped by an `EXIT` trap, and **explicitly killed in `exit_script`** before its `exec bash -l` (which replaces the process and would otherwise bypass the EXIT trap, leaving the loop refreshing sudo for the whole post-install shell session).
- Wired into both `setup_macos.sh` and `setup_ubuntu.sh` (replacing the lone `sudo -v`). Does **not** clobber the existing `ERR` trap (different signal).

## 2. `brew bundle` aborts on google-chrome
```
Error: Cask 'google-chrome' is unreadable: undefined method 'appcast' for Cask 'google-chrome'
`brew bundle` failed! Failed to fetch speedtest, 1password, ...
```
A stale local cask `.rb` (cached per-install via `FromInstalledPathLoader`, or a leftover `homebrew-cask` tap checkout) still references the `appcast` stanza **removed in Homebrew 4.3**, shadowing the live API cask and aborting the entire bundle. Fix in `install_packages()`:

- `brew untap --force homebrew/core homebrew/cask` + `rm -rf` any leftover `Library/Taps/homebrew/homebrew-{core,cask}` checkout.
- Purge stale cached cask sources: `find "$Caskroom" -path '*/.metadata/*' -name '*.rb' -delete`, and drop `"$(brew --cache)/Cask"` (guarded so an empty cache path can't expand to `/Cask`).
- `brew update-reset` so the JSON API is the source of truth.
- Make `brew bundle` non-fatal (`|| log …`) so one unreadable cask can't abort the rest of setup. **google-chrome stays in the Brewfile** and installs from the current API cask.

Root cause confirmed against Homebrew/homebrew-cask #177011, #173201 and Homebrew discussion #5373.

## Testing
- `bash -n` + `shfmt -d` clean on all three scripts (the one shellcheck error, `setup_ubuntu.sh` `install_open_rgb_rules`, is pre-existing and unrelated — that function is commented out in `main()`).
- Keepalive verified at runtime with a stubbed `sudo`: spawns exactly one loop, second call is a no-op, survives `set -e`, and the loop PID is reaped immediately when the parent exits (no leak).

> Researched and drafted via two parallel subagents; patches reviewed, hardened (guarded `brew --cache` deletion; explicit `exit_script` kill), and verified before applying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve macOS and Ubuntu setup scripts to use a robust sudo keepalive and harden Homebrew package installation against stale cask metadata failures.

Bug Fixes:
- Ensure sudo is prompted for once and kept alive during long macOS and Ubuntu setup runs to avoid repeated password prompts.
- Prevent Homebrew brew bundle from failing due to stale tap checkouts or cached cask .rb metadata that reference removed appcast stanzas.

Enhancements:
- Make brew bundle non-fatal so a single unreadable cask does not abort the entire setup process.
- Reset and clean Homebrew taps, repositories, and caches to prefer API-based casks and reduce local clutter.