### PR TITLE
Linux: replace unmaintained WhatsApp flatpak with ZapZap

### DIFF
--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -226,7 +226,7 @@ install_flatpaks() {
 		org.openrgb.OpenRGB \
 		org.mozilla.Thunderbird \
 		com.spotify.Client \
-		com.github.eneshecan.WhatsAppForLinux \
+		com.rtosta.zapzap \
 		org.remmina.Remmina \
 		com.sublimetext.three \
 		com.valvesoftware.Steam \


### PR DESCRIPTION
## What
Swap the Linux WhatsApp flatpak in `install_flatpaks()`:

```diff
-		com.github.eneshecan.WhatsAppForLinux \
+		com.rtosta.zapzap \
```

## Why
`com.github.eneshecan.WhatsAppForLinux` is a WebKitGTK wrapper still pinned to the **EOL `org.gnome.Platform/45`** runtime (WebKitGTK 2.42; last Flathub build 2024-07-30). WhatsApp Web has outgrown that engine, so the app launches and connects (HTTP 200) but never renders — a blank/stuck window.

**ZapZap** (`com.rtosta.zapzap`, v6.5.1, updated 2026-06-14) is an actively maintained Qt6/QtWebEngine client on `org.kde.Platform/6.10` — a modern Chromium engine WhatsApp Web supports.

## macOS
Unaffected. The `Brewfile` already uses the official `cask "whatsapp"` native app, and ZapZap has no macOS build (no Homebrew cask exists).

## Verification
- `shfmt -d tools/setup_ubuntu.sh` — clean
- `shellcheck` — no new findings introduced by this change
- Confirmed `com.rtosta.zapzap` resolves on Flathub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

New Features:
- Install ZapZap (com.rtosta.zapzap) as the default WhatsApp client Flatpak on Linux.