### PR TITLE
Linux: grant ZapZap home filesystem access after install

### DIFF
--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -243,6 +243,10 @@ install_flatpaks() {
 			log "Failed to install $app - continuing with next application"
 		fi
 	done
+
+	# ZapZap is sandboxed and only sees XDG dirs by default; grant access to
+	# $HOME so it can attach and save files anywhere in the home directory.
+	flatpak override --user --filesystem=home com.rtosta.zapzap
 }
 
 install_browser() {


### PR DESCRIPTION
## What
Add a `flatpak override` after the install loop in `install_flatpaks()`:

```sh
flatpak override --user --filesystem=home com.rtosta.zapzap
```

## Why
ZapZap (`com.rtosta.zapzap`) runs in a flatpak sandbox that, by default, only exposes XDG directories. Granting `--filesystem=home` lets it attach and save files anywhere in `$HOME` (otherwise attachments/downloads outside the default dirs fail).

Follow-up to the ZapZap swap (#191).

## Verification
- `shfmt -d tools/setup_ubuntu.sh` — clean
- `shellcheck` — no findings on the new lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Add a post-install flatpak override for ZapZap to expose the user home filesystem.