### PR TITLE
Install Foundry on macOS and Ubuntu

### DIFF
--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -126,6 +126,7 @@ export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/shims:$PATH"
 export PATH=$PATH:$HOME/.local/share/JetBrains/Toolbox/scripts
 export PATH=$PATH:$HOME/.local/bin
 export PATH="$HOME/go/bin:$PATH"
+export PATH="$HOME/.foundry/bin:$PATH"
 if command -v pyenv >/dev/null 2>&1; then
 	alias brew='env PATH="${PATH//$(pyenv root)\/shims:/}" brew'
 	# Lazy-load pyenv init (saves ~2s on shell startup).

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -149,6 +149,15 @@ install_starship() {
 	fi
 }
 
+install_foundry() {
+	print_function_name
+	# Foundry (forge, cast, anvil, chisel) via the official installer — NOT snap.
+	# foundryup installs to ~/.foundry/bin (added to PATH in .bashrc).
+	curl -L https://foundry.paradigm.xyz | bash
+	"$HOME/.foundry/bin/foundryup"
+	"$HOME/.foundry/bin/cast" --version
+}
+
 install_pyenv() {
 	print_function_name
 	local os_type

--- a/tools/setup_macos.sh
+++ b/tools/setup_macos.sh
@@ -255,15 +255,6 @@ install_rust() {
 	rustup update stable
 }
 
-install_foundry() {
-	print_function_name
-	# Foundry (forge, cast, anvil, chisel) via the official installer — NOT snap.
-	# foundryup installs to ~/.foundry/bin (added to PATH in .bashrc).
-	curl -L https://foundry.paradigm.xyz | bash
-	"$HOME/.foundry/bin/foundryup"
-	"$HOME/.foundry/bin/cast" --version
-}
-
 install_node() {
 	print_function_name
 	# Node is installed via Homebrew

--- a/tools/setup_macos.sh
+++ b/tools/setup_macos.sh
@@ -255,6 +255,15 @@ install_rust() {
 	rustup update stable
 }
 
+install_foundry() {
+	print_function_name
+	# Foundry (forge, cast, anvil, chisel) via the official installer — NOT snap.
+	# foundryup installs to ~/.foundry/bin (added to PATH in .bashrc).
+	curl -L https://foundry.paradigm.xyz | bash
+	"$HOME/.foundry/bin/foundryup"
+	"$HOME/.foundry/bin/cast" --version
+}
+
 install_node() {
 	print_function_name
 	# Node is installed via Homebrew
@@ -455,6 +464,7 @@ main() {
 	run_function install_ruby
 	run_function install_pyenv
 	run_function install_rust
+	run_function install_foundry
 	run_function install_node
 	run_function install_go
 	run_function setup_docker

--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -394,15 +394,6 @@ install_rust() {
 	rustup update stable
 }
 
-install_foundry() {
-	print_function_name
-	# Foundry (forge, cast, anvil, chisel) via the official installer — NOT snap.
-	# foundryup installs to ~/.foundry/bin (added to PATH in .bashrc).
-	curl -L https://foundry.paradigm.xyz | bash
-	"$HOME/.foundry/bin/foundryup"
-	"$HOME/.foundry/bin/cast" --version
-}
-
 go_installs() {
 	print_function_name
 	go install github.com/dim13/otpauth@latest

--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -394,6 +394,15 @@ install_rust() {
 	rustup update stable
 }
 
+install_foundry() {
+	print_function_name
+	# Foundry (forge, cast, anvil, chisel) via the official installer — NOT snap.
+	# foundryup installs to ~/.foundry/bin (added to PATH in .bashrc).
+	curl -L https://foundry.paradigm.xyz | bash
+	"$HOME/.foundry/bin/foundryup"
+	"$HOME/.foundry/bin/cast" --version
+}
+
 go_installs() {
 	print_function_name
 	go install github.com/dim13/otpauth@latest
@@ -978,6 +987,7 @@ main() {
 	run_function install_vscode
 	run_function install_flatpaks
 	run_function install_rust
+	run_function install_foundry
 	run_function install_and_setup_docker
 	run_function install_github_cli
 	run_function install_espanso


### PR DESCRIPTION
## Summary
Adds [Foundry](https://book.getfoundry.sh/) (`forge`, `cast`, `anvil`, `chisel`) to the automated setup on both macOS and Ubuntu, so tools like `cast balance` are available out of the box.

- New `install_foundry` function in `tools/setup_macos.sh` and `tools/setup_ubuntu.sh`, wired into each `main()` right after `install_rust`.
- Uses the official Paradigm installer (`curl -L https://foundry.paradigm.xyz | bash` → `foundryup`) — **not snap**, per the request.
- Binaries install to `~/.foundry/bin`; added that to `PATH` in `dotfiles/.bashrc` (the repo overwrites `.bashrc` on setup, so foundryup's own PATH edit would otherwise be clobbered).
- Each function calls `cast --version` at the end as a smoke check.

## Verification
Installed locally via the same installer and confirmed the target query works:

```
OP=0x601b691a3c6372d6d7345df4f7e5d30d51535acd
cast balance $OP --rpc-url https://api.infra.mainnet.somnia.network/ -e
→ 100099.999874000000000000
```

`shfmt -d` is clean on all changed files. Remaining `shellcheck` findings are pre-existing across the repo and untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add Foundry tooling to the automated macOS and Ubuntu setup so Ethereum development commands are available by default.

New Features:
- Install Foundry (forge, cast, anvil, chisel) via the official installer in macOS and Ubuntu setup scripts and run a basic cast version check.
- Expose the Foundry binary directory by adding ~/.foundry/bin to the default shell PATH in the provided .bashrc.