### PR TITLE
Add ~/.cargo/bin to PATH in .profile

### DIFF
--- a/dotfiles/.profile
+++ b/dotfiles/.profile
@@ -26,6 +26,11 @@ if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"
 fi
 
+# set PATH so it includes rust/cargo binaries if they exist
+if [ -d "$HOME/.cargo/bin" ] ; then
+    PATH="$HOME/.cargo/bin:$PATH"
+fi
+
 # Deduplicate PATH, preserving order (exact match, not substring)
 declare -A _seen_paths
 _new_path=()


### PR DESCRIPTION
## Summary
- Rust binaries (`cargo`, `rustc`, `rustup`) install into `~/.cargo/bin`, but `.profile` never added that directory to PATH for regular shell sessions — setup only sourced `~/.cargo/env` during provisioning, so `cargo` was unavailable in normal shells.
- Prepend `$HOME/.cargo/bin` to PATH when it exists, following the existing `~/bin` and `~/.local/bin` blocks. The existing dedup block keeps PATH clean.

## Testing
- Shell-only change; verified logic mirrors the surrounding conditional PATH additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Prepend $HOME/.cargo/bin to PATH in .profile when the directory exists, aligning it with existing PATH additions for user-local binaries.