### PR TITLE
Add ~/.cargo/bin to PATH in .bashrc

### DIFF
--- a/dotfiles/.bashrc
+++ b/dotfiles/.bashrc
@@ -127,6 +127,7 @@ export PATH=$PATH:$HOME/.local/share/JetBrains/Toolbox/scripts
 export PATH=$PATH:$HOME/.local/bin
 export PATH="$HOME/go/bin:$PATH"
 export PATH="$HOME/.foundry/bin:$PATH"
+export PATH="$HOME/.cargo/bin:$PATH"
 if command -v pyenv >/dev/null 2>&1; then
 	alias brew='env PATH="${PATH//$(pyenv root)\/shims:/}" brew'
 	# Lazy-load pyenv init (saves ~2s on shell startup).


### PR DESCRIPTION
## Summary
- The earlier PR (#196) added `~/.cargo/bin` to `.profile`, but `.profile` is only read by **login** shells. A new terminal window starts an **interactive non-login** shell, which reads `.bashrc` and never sources `.profile` — so `cargo` still wasn't found in fresh terminals.
- Add `$HOME/.cargo/bin` to PATH in `.bashrc`, alongside the existing interactive PATH additions (pyenv, go, foundry, `.local/bin`). This is the path that actually runs for every interactive terminal.

## Testing
- Confirmed `~/.cargo/bin` exists and contains `cargo`/`rustup` on the machine, but was absent from PATH in a non-login shell before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Include $HOME/.cargo/bin in PATH setup for interactive Bash shells alongside existing language toolchains.