### PR TITLE
Add yodex alias for unrestricted Codex

### DIFF
--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -1357,6 +1357,7 @@ magpie_mirror() {
 
 # Fun
 alias yolo='claude --dangerously-skip-permissions'
+alias yodex='codex --dangerously-bypass-approvals-and-sandbox'
 
 function laughing_at_idiots() {
 	# sudo apt-get install -y fswebcam imagemagick


### PR DESCRIPTION
## Summary

- add a yodex alias matching the existing yolo convenience alias
- launch Codex with approvals and sandboxing bypassed

## Checks

- bash -n dotfiles/.bash_aliases
- sourced the aliases file and verified yodex resolves correctly

## Summary by Sourcery

New Features:
- Introduce a yodex bash alias that launches Codex with approvals and sandboxing bypassed.