### PR TITLE
Add remote unlock shell helper

### DIFF
--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -82,6 +82,15 @@ function tailfix() {
 	\tail -f $@ | sed 's/\x1/|/g'
 }
 
+function unlock() {
+	if [ "$#" -ne 1 ]; then
+		echo "Usage: unlock machine"
+		return 1
+	fi
+
+	ssh "$1" 'loginctl unlock-sessions'
+}
+
 function scp_mirror() {
 	# Usage
 	# $ scp_mirror alex-home ~/.netrc ~/vpn/ ~/.aws ~/.personal ~/.packagr_details


### PR DESCRIPTION
## Summary
- add an `unlock` Bash function that accepts an SSH machine name
- remotely unlock graphical sessions with `loginctl unlock-sessions`
- validate that exactly one machine name is supplied

## Testing
- `bash -n dotfiles/.bash_aliases`
- mocked SSH invocation for `unlock alex-work`
- verified missing-argument usage and exit status

## Summary by Sourcery

New Features:
- Introduce an unlock Bash function that unlocks sessions on a remote machine via SSH and loginctl.