### PR TITLE
Fix remote unlock authorization

### DIFF
--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -88,7 +88,7 @@ function unlock() {
 		return 1
 	fi
 
-	ssh "$1" 'loginctl unlock-sessions'
+	ssh "$1" 'sudo -n /usr/bin/loginctl unlock-sessions'
 }
 
 function scp_mirror() {

--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -192,6 +192,26 @@ ssh_stuff() {
 	sudo systemctl reload ssh
 }
 
+configure_remote_unlock() {
+	print_function_name
+	local sudoers_file="/etc/sudoers.d/remote-unlock"
+	local sudoers_rule="$USER ALL=(root) NOPASSWD: /usr/bin/loginctl unlock-sessions"
+	local temp_file
+	temp_file=$(mktemp)
+
+	printf '%s\n' "$sudoers_rule" >"$temp_file"
+	chmod 0440 "$temp_file"
+	sudo visudo -cf "$temp_file"
+
+	if sudo cmp -s "$temp_file" "$sudoers_file"; then
+		rm -f "$temp_file"
+		return
+	fi
+
+	sudo install -o root -g root -m 0440 "$temp_file" "$sudoers_file"
+	rm -f "$temp_file"
+}
+
 install_pg_formatter() {
 	echo "Installing pg_formatter..."
 
@@ -967,6 +987,7 @@ main() {
 	run_function set_git_config
 	run_function install_apt_packages
 	run_function ssh_stuff
+	run_function configure_remote_unlock
 	run_function install_pyenv
 	run_function install_pg_formatter
 	run_function install_browser


### PR DESCRIPTION
Use narrowly scoped non-interactive sudo for the remote `loginctl unlock-sessions` call.

The target machine must allow `/usr/bin/loginctl unlock-sessions` via a `NOPASSWD` sudoers rule.

## Summary by Sourcery

Enhancements:
- Update remote unlock helper to call loginctl via non-interactive, path-qualified sudo for better security and authorization control.