### PR TITLE
Add carclean and quiet formatter output

### DIFF
--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -330,6 +330,50 @@ filecount_table() {
 }
 
 # Rust
+function carclean() {
+	local root="$PWD"
+	local directory cargo_output removed_line amount directory_name
+	local index=0 failed=0 directory_width=9 amount_width=14
+	local directories=() amounts=() cargo_outputs=()
+
+	for directory in "$root"/*/; do
+		[ -d "$directory" ] || continue
+		[ -f "$directory/Cargo.toml" ] || continue
+
+		directory_name="$(basename "${directory%/}")"
+		directories[index]="$directory_name"
+
+		if cargo_output=$(cd "$directory" && cargo clean 2>&1); then
+			cargo_outputs[index]="$cargo_output"
+			removed_line=$(printf '%s\n' "${cargo_outputs[index]}" | \grep 'Removed ' | tail -n 1 || true)
+			if [[ "$removed_line" =~ ,[[:space:]]+([^[:space:]]+)[[:space:]]+total ]]; then
+				amount="${BASH_REMATCH[1]}"
+			elif [[ "$removed_line" =~ Removed[[:space:]]+0[[:space:]]+files? ]]; then
+				amount="0 B"
+			else
+				amount="Unknown"
+			fi
+		else
+			cargo_outputs[index]="$cargo_output"
+			amount="ERROR"
+			failed=1
+		fi
+
+		amounts[index]="$amount"
+		((${#directory_name} > directory_width)) && directory_width=${#directory_name}
+		((${#amount} > amount_width)) && amount_width=${#amount}
+		index=$((index + 1))
+	done
+
+	printf '| %-*s | %-*s |\n' "$directory_width" "Directory" "$amount_width" "Amount cleaned"
+	printf '|-%s-|-%s-|\n' "$(printf '%*s' "$directory_width" '' | tr ' ' '-')" "$(printf '%*s' "$amount_width" '' | tr ' ' '-')"
+	for index in "${!directories[@]}"; do
+		printf '| %-*s | %-*s |\n' "$directory_width" "${directories[index]}" "$amount_width" "${amounts[index]}"
+	done
+
+	return "$failed"
+}
+
 function clippy() {
 	local current_toolchain=$(rustup show active-toolchain | cut -d '-' -f1)
 	echo "Current toolchain: $current_toolchain"
@@ -1241,39 +1285,104 @@ _fmt_files() {
 	fi
 }
 
+_formatter_run_quiet() {
+	local output
+	local status
+
+	output="$("$@" 2>&1)"
+	status=$?
+	if [ "$status" -ne 0 ] && [ -n "$output" ]; then
+		printf '%s\n' "$output" >&2
+	fi
+	return "$status"
+}
+
+_formatter_run_file() {
+	local file="$1"
+	local before
+	local status
+	shift
+
+	before="$(mktemp "${TMPDIR:-/tmp}/formatter.XXXXXX")" || return 1
+	cp "./${file#./}" "$before" || {
+		rm -f "$before"
+		return 1
+	}
+
+	_formatter_run_quiet "$@"
+	status=$?
+	if ! cmp -s "$before" "./${file#./}"; then
+		log "$file"
+	fi
+	rm -f "$before"
+	return "$status"
+}
+
+_formatter_snapshot_files() {
+	local snapshot_dir="$1"
+	local file
+	local index=0
+	shift
+
+	: >"$snapshot_dir/files"
+	_fmt_files "$@" | while IFS= read -r file; do
+		printf '%s\n' "$file" >>"$snapshot_dir/files"
+		cp "./${file#./}" "$snapshot_dir/$index"
+		index=$((index + 1))
+	done
+}
+
+_formatter_log_snapshot_changes() {
+	local snapshot_dir="$1"
+	local file
+	local index=0
+
+	while IFS= read -r file; do
+		if ! cmp -s "$snapshot_dir/$index" "./${file#./}"; then
+			log "$file"
+		fi
+		index=$((index + 1))
+	done <"$snapshot_dir/files"
+}
+
 # Set JSON_LINE_WIDTH to control max line width for simple arrays (default: 80)
 formatter_json() {
 	local line_width="${JSON_LINE_WIDTH:-80}"
 
 	_fmt_files '*.json' '*.json5' | while read -r file; do
-		log "Processing $file"
+		local before
+		before="$(mktemp "${TMPDIR:-/tmp}/formatter.XXXXXX")" || continue
+		cp "./${file#./}" "$before" || {
+			rm -f "$before"
+			continue
+		}
 
 		# Reformat in place: sort keys, align colons, pack scalar arrays
 		# wide, and PRESERVE comments. Parses json and json5 natively (no
 		# json5->json pre-pass), so // and /* */ comments survive on both.
 		# Heavy lifting lives in ~/.local/bin/json_formatter.py (copied by setup).
-		python3 "$HOME/.local/bin/json_formatter.py" "$file" "$line_width" 2>/dev/null || {
-			log "Failed to parse $file, falling back to jq"
+		_formatter_run_quiet python3 "$HOME/.local/bin/json_formatter.py" "$file" "$line_width" || {
 			if command -v jq &>/dev/null; then
 				jq -S '.' "$file" >"$file.tmp" && mv "$file.tmp" "$file"
 			fi
 		}
+		if ! cmp -s "$before" "./${file#./}"; then
+			log "$file"
+		fi
+		rm -f "$before"
 	done
 }
 
 formatter_sql() {
 	_fmt_files '*.sql' | while read -r file; do
-		log "Processing $file"
-
-		pg_format --keyword-case=2 --type-case=2 --comma-break --no-extra-line --inplace "$file"
+		_formatter_run_file "$file" pg_format --keyword-case=2 --type-case=2 --comma-break --no-extra-line --inplace "$file"
 	done
 }
 
 formatter_shell() {
 	_fmt_files '*.sh' '.bashrc' '.bash_aliases' |
 		while read -r file; do
-			log "Processing $file"
-			shfmt -l -w "$file"
+			_formatter_run_file "$file" shfmt -w "$file"
 		done
 }
 
@@ -1284,6 +1393,8 @@ alias ta='terraform apply'
 alias taaa='terraform apply --auto-approve'
 
 formatter() {
+	local snapshot_dir
+
 	formatter_json &
 	formatter_sql &
 	formatter_shell &
@@ -1292,35 +1403,35 @@ formatter() {
 	if [ -f pyproject.toml ] || ls *.py &>/dev/null || [ -d .venv/ ]; then
 		if [ -n "$VIRTUAL_ENV" ]; then
 			if command -v ruff &>/dev/null; then
-				log "Running ruff check..."
-				ruff check --fix .
-				log "Running ruff format..."
-				ruff format .
-			else
-				log "ruff not found. Skipping Python linting/formatting."
+				snapshot_dir="$(mktemp -d "${TMPDIR:-/tmp}/formatter.XXXXXX")" || return 1
+				_formatter_snapshot_files "$snapshot_dir" '*.py' '*.pyi' '*.ipynb'
+				_formatter_run_quiet ruff check --fix --quiet .
+				_formatter_run_quiet ruff format --quiet .
+				_formatter_log_snapshot_changes "$snapshot_dir"
+				rm -rf "$snapshot_dir"
 			fi
-		else
-			log "Python project detected, but not in a uv environment. Skipping Python linting/formatting."
 		fi
 	fi
 
 	# Check for Rust project
 	if [ -f Cargo.toml ]; then
 		if command -v cargo &>/dev/null; then
-			log "Running cargo +nightly fmt..."
-			cargo +nightly fmt
-		else
-			log "cargo not found. Skipping Rust formatting."
+			snapshot_dir="$(mktemp -d "${TMPDIR:-/tmp}/formatter.XXXXXX")" || return 1
+			_formatter_snapshot_files "$snapshot_dir" '*.rs'
+			_formatter_run_quiet cargo +nightly fmt
+			_formatter_log_snapshot_changes "$snapshot_dir"
+			rm -rf "$snapshot_dir"
 		fi
 	fi
 
 	# Terraform (terraform fmt)
 	if find . -name "*.tf" | grep -q .; then
 		if command -v terraform &>/dev/null; then
-			log "Running terraform fmt --recursive..."
-			terraform fmt --recursive
-		else
-			log "terraform not found. Skipping Terraform formatting."
+			snapshot_dir="$(mktemp -d "${TMPDIR:-/tmp}/formatter.XXXXXX")" || return 1
+			_formatter_snapshot_files "$snapshot_dir" '*.tf'
+			_formatter_run_quiet terraform fmt --recursive
+			_formatter_log_snapshot_changes "$snapshot_dir"
+			rm -rf "$snapshot_dir"
 		fi
 	fi
 }

--- a/tests/carclean/run.sh
+++ b/tests/carclean/run.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+aliases="$repo_root/dotfiles/.bash_aliases"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/bin" "$tmp/work/alpha crate" "$tmp/work/bravo" "$tmp/work/not-rust"
+touch "$tmp/work/alpha crate/Cargo.toml" "$tmp/work/bravo/Cargo.toml"
+
+cat >"$tmp/bin/cargo" <<'EOF'
+#!/usr/bin/env bash
+[ "$1" = clean ] || exit 2
+case "${PWD##*/}" in
+"alpha crate") printf '     Removed 12 files, 1.2MiB total\n' >&2 ;;
+bravo) printf '     Removed 0 files\n' >&2 ;;
+*) exit 3 ;;
+esac
+EOF
+chmod +x "$tmp/bin/cargo"
+
+# shellcheck source=/dev/null
+source "$aliases"
+
+export PATH="$tmp/bin:$PATH"
+start_dir="$tmp/work"
+cd "$start_dir" || exit 1
+
+output=$(carclean)
+status=$?
+
+if [ "$status" -ne 0 ]; then
+	printf 'FAIL: carclean returned %s\n' "$status"
+	exit 1
+fi
+
+if [ "$PWD" != "$start_dir" ]; then
+	printf 'FAIL: carclean changed directory to %s\n' "$PWD"
+	exit 1
+fi
+
+if [[ "$output" != *'| alpha crate | 1.2MiB'* ]]; then
+	printf 'FAIL: missing cleaned amount for alpha crate\n%s\n' "$output"
+	exit 1
+fi
+
+if [[ "$output" != *'| bravo       | 0 B'* ]]; then
+	printf 'FAIL: missing zero cleaned amount for bravo\n%s\n' "$output"
+	exit 1
+fi
+
+if [[ "$output" == *not-rust* ]]; then
+	printf 'FAIL: non-Rust directory appeared in output\n%s\n' "$output"
+	exit 1
+fi
+
+printf 'PASS: carclean cleaned immediate Rust subdirectories and summarised the results\n'

--- a/tests/formatter/run.sh
+++ b/tests/formatter/run.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Self-contained test for formatter_json: proves comments are preserved on both
-# .json and .json5, keys are sorted, colons aligned, and json5 normalises to
-# strict JSON. Copies fixtures to a temp dir so the committed inputs are never
-# reformatted in place. Exits non-zero on any mismatch.
+# Self-contained test for formatter: proves it reports only files it changed,
+# and that JSON comments are preserved on both .json and .json5, keys are
+# sorted, colons aligned, and json5 normalises to strict JSON. Copies fixtures
+# to a temp dir so the committed inputs are never reformatted in place.
 set -u
 
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -17,12 +17,49 @@ cp "$here/input.json" "$here/input.json5" "$tmp/"
 # shellcheck source=/dev/null
 source "$aliases"
 
-(
+first_output="$({
 	cd "$tmp" || exit 1
-	formatter_json
-)
+	formatter
+})"
 
 status=0
+line_count="$(printf '%s\n' "$first_output" | grep -c .)"
+if [ "$line_count" -eq 2 ]; then
+	echo "PASS: formatter reported exactly two modified files"
+else
+	echo "FAIL: formatter produced $line_count lines; expected exactly two:"
+	printf '%s\n' "$first_output"
+	status=1
+fi
+
+unexpected_output="$(printf '%s\n' "$first_output" | grep -Ev '^[0-9]{4}-[0-9]{2}-[0-9]{2} .* - (\./)?input\.(json|json5)$' || true)"
+if [ -n "$unexpected_output" ]; then
+	echo "FAIL: formatter produced unexpected output:"
+	printf '%s\n' "$unexpected_output"
+	status=1
+fi
+
+for ext in json json5; do
+	if printf '%s\n' "$first_output" | grep -Eq "^[0-9]{4}-[0-9]{2}-[0-9]{2} .* - (\./)?input\.$ext$"; then
+		echo "PASS: modified input.$ext reported with a timestamp"
+	else
+		echo "FAIL: modified input.$ext was not reported with a timestamp"
+		status=1
+	fi
+done
+
+second_output="$({
+	cd "$tmp" || exit 1
+	formatter
+})"
+if [ -z "$second_output" ]; then
+	echo "PASS: already formatted files are not reported"
+else
+	echo "FAIL: formatter reported files it did not modify:"
+	printf '%s\n' "$second_output"
+	status=1
+fi
+
 for ext in json json5; do
 	if diff -u "$here/expected.$ext" "$tmp/input.$ext"; then
 		echo "PASS: input.$ext formatted as expected (comments preserved)"


### PR DESCRIPTION
## Summary

- add carclean to clean immediate Rust child projects and print a directory/amount summary
- report only files actually changed by formatter, using timestamped log output
- add coverage for carclean and formatter idempotency/output

## Verification

- bash tests/carclean/run.sh
- bash tests/formatter/run.sh
- bash -n dotfiles/.bash_aliases tests/carclean/run.sh tests/formatter/run.sh
- shellcheck error-level checks
- shfmt -d tests/carclean/run.sh tests/formatter/run.sh
- git diff --check

## Summary by Sourcery

Add a carclean helper for Rust projects and make the formatter only log files it actually changes, with tests covering both behaviors.

New Features:
- Introduce a carclean shell function to clean immediate Rust child projects and summarise per-directory cleaned size.
- Extend the formatter to report only files whose contents changed, using timestamped log entries.

Tests:
- Add formatter tests that verify change-only logging, timestamped output, and idempotent behavior.
- Add carclean tests that validate Rust subdirectory detection, cleaned-size reporting, and directory preservation during execution.