### PR TITLE
Suppress formatter job-control output

### DIFF
--- a/dotfiles/.bash_aliases
+++ b/dotfiles/.bash_aliases
@@ -1395,10 +1395,11 @@ alias taaa='terraform apply --auto-approve'
 formatter() {
 	local snapshot_dir
 
-	formatter_json &
-	formatter_sql &
-	formatter_shell &
-	wait
+	# Keep these in the foreground so interactive shells do not print job IDs
+	# and completion notices around the formatter's own timestamped output.
+	formatter_json
+	formatter_sql
+	formatter_shell
 	# Check for Python project
 	if [ -f pyproject.toml ] || ls *.py &>/dev/null || [ -d .venv/ ]; then
 		if [ -n "$VIRTUAL_ENV" ]; then

--- a/tests/formatter/run.sh
+++ b/tests/formatter/run.sh
@@ -60,6 +60,18 @@ else
 	status=1
 fi
 
+# Interactive shells announce commands launched with `&` using output such as
+# "[1] 12345" and "[1] Done". The top-level formatter should not leak those
+# job-control messages around its own timestamped file output.
+interactive_output="$(bash --noprofile --norc -ic "source '$aliases'; cd '$tmp'; formatter" 2>&1)"
+if printf '%s\n' "$interactive_output" | grep -Eq '^\[[0-9]+\]'; then
+	echo "FAIL: formatter produced interactive job-control output:"
+	printf '%s\n' "$interactive_output"
+	status=1
+else
+	echo "PASS: formatter produces no interactive job-control output"
+fi
+
 for ext in json json5; do
 	if diff -u "$here/expected.$ext" "$tmp/input.$ext"; then
 		echo "PASS: input.$ext formatted as expected (comments preserved)"


### PR DESCRIPTION
## Summary

- run JSON, SQL, and shell formatter passes in deterministic foreground order
- prevent interactive shells from printing job IDs and completion notices
- add an interactive-shell regression test for job-control output

## Verification

- bash tests/formatter/run.sh
- bash -n dotfiles/.bash_aliases tests/formatter/run.sh
- shellcheck error-level checks
- shfmt -d tests/formatter/run.sh
- git diff --check

## Summary by Sourcery

Ensure the formatter runs its JSON, SQL, and shell passes sequentially in the foreground and add coverage to prevent interactive job-control output from leaking into formatter output.

New Features:
- Add a regression test that runs the formatter in an interactive, non-profiled bash shell and asserts that no job-control messages are emitted.

Enhancements:
- Change the formatter helper to run JSON, SQL, and shell formatting passes sequentially instead of in the background to keep output clean in interactive shells.

Tests:
- Extend the formatter test script with an interactive-shell check for unwanted job-control messages in formatter output.