### PR TITLE
Disable Homebrew upgrade prompts and trust speedtest

### DIFF
--- a/tools/Brewfile
+++ b/tools/Brewfile
@@ -41,7 +41,7 @@ brew "scc"
 brew "shellcheck"
 brew "starship"
 brew "shfmt"
-tap "teamookla/speedtest"
+tap "teamookla/speedtest", trusted: { formula: "speedtest" }
 brew "speedtest"
 brew "sqlite3"
 brew "syncthing"

--- a/tools/setup_macos.sh
+++ b/tools/setup_macos.sh
@@ -10,9 +10,10 @@ export PATH="$HOME/.local/bin:$PATH"
 export PROFILE_DIR=$(pwd)
 export ARCHITECTURE=$(uname -m)
 # Upstream installers should use the sudo ticket primed below and must not stop
-# for their own confirmation prompts. HOMEBREW_ASK can be inherited from a
-# user's shell and explicitly enables confirmation prompts, so clear it.
+# for their own confirmation prompts. Homebrew CLI ask mode is now the default;
+# HOMEBREW_NO_ASK disables it, while NONINTERACTIVE covers its bootstrap script.
 export NONINTERACTIVE=1
+export HOMEBREW_NO_ASK=1
 export GIT_TERMINAL_PROMPT=0
 export GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=10"
 unset INTERACTIVE HOMEBREW_ASK


### PR DESCRIPTION
## Summary

- set `HOMEBREW_NO_ASK=1` because ask mode is now Homebrew CLI’s default
- retain `NONINTERACTIVE=1` for the Homebrew bootstrap installer
- declaratively trust only the Ookla speedtest formula required by the Brewfile
- keep tap security enabled for every unrelated third-party tap

## Validation

- verified `/opt/homebrew` 6.0.11 recognizes `HOMEBREW_NO_ASK`
- verified `brew upgrade --greedy --dry-run` produces no confirmation prompt
- applied the Brewfile with all package types skipped and confirmed it records only `teamookla/speedtest/speedtest` as trusted
- fetched the trusted Ookla formula successfully
- `/bin/bash -n`, `shfmt`, targeted `shellcheck`, and `git diff --check`

## Summary by Sourcery

Ensure macOS setup runs Homebrew non-interactively while explicitly trusting only the required Ookla speedtest formula.

Enhancements:
- Set HOMEBREW_NO_ASK alongside NONINTERACTIVE to prevent Homebrew CLI confirmation prompts during macOS setup.
- Restrict Brewfile tap trust to the Ookla speedtest formula while keeping other third-party taps untrusted by default.