### PR TITLE
Do not launch Docker Desktop during macOS setup

### DIFF
--- a/tools/setup_macos.sh
+++ b/tools/setup_macos.sh
@@ -343,10 +343,7 @@ setup_docker() {
 		ln -sfn /opt/homebrew/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
 	fi
 
-	# Start Docker Desktop
-	if [ -d "/Applications/Docker.app" ]; then
-		open -a Docker
-	fi
+	# Docker Desktop is installed by the Brewfile but started only by the user.
 }
 
 setup_vscode() {


### PR DESCRIPTION
## Summary

- stop opening Docker Desktop during macOS setup
- retain Docker Desktop installation through the Brewfile
- retain the Docker Compose CLI plugin symlink

## Validation

- `/bin/bash -n tools/setup_macos.sh`
- `shfmt -d tools/setup_macos.sh`
- targeted `shellcheck`
- verified `open -a Docker` is absent

## Summary by Sourcery

Enhancements:
- Clarify Docker setup behavior so Docker Desktop is installed via Brewfile but only started manually by the user.