### PR TITLE
fix(macos): restore missing cask applications

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,29 @@
+# Repair missing Homebrew cask applications
+
+- [x] Reproduce the stale-receipt state where Homebrew reports a cask installed
+      but its declared application artifact is absent.
+- [x] Repair installed casks whose application artifacts are missing without
+      repeatedly reinstalling non-application casks such as fonts.
+- [x] Verify the focused behaviour and run `shellcheck` and `shfmt -d`.
+- [x] Restore 1Password on the current Mac and confirm its application exists.
+- [x] Obtain an independent review and resolve any material findings.
+
+## Review
+
+- [x] Added a shared application-artifact path resolver and completeness check;
+      installed casks are reinstalled when any declared app is absent.
+- [x] Covered present, missing, partial multi-app, font-only, renamed, absolute,
+      unmanaged-app, and invalid-receipt cases with stubbed Homebrew responses.
+- [x] Confirmed the live 1Password state was detected as incomplete, reinstalled
+      8.12.33, verified its code signature, and confirmed the receipt and app.
+- [x] `bash -n` and `shfmt -d` pass. The changed script adds no ShellCheck
+      findings relative to `origin/main`; the repository-wide command retains
+      unrelated pre-existing findings.
+- [x] Existing `carclean` and `formatter` tests pass. The formatter test needs
+      the native `/opt/homebrew` toolchain before the broken Intel Python.
+- [x] Independent review found no material correctness, scope, or verification
+      concerns.
+
 # Fix espanso so it actually works (Ubuntu/Wayland)
 
 ## Environment (verified live)

--- a/tools/setup_macos.sh
+++ b/tools/setup_macos.sh
@@ -206,7 +206,7 @@ install_homebrew() {
 	export HOMEBREW_NO_INSTALL_FROM_API=0
 }
 
-cask_has_existing_app_artifact() {
+cask_app_artifact_paths() {
 	local cask="$1"
 	local applications_dir="${APPLICATIONS_DIR:-/Applications}"
 	local artifact
@@ -221,9 +221,7 @@ cask_has_existing_app_artifact() {
 		/*) artifact_path="$artifact" ;;
 		*) artifact_path="$applications_dir/${artifact##*/}" ;;
 		esac
-		if [ -e "$artifact_path" ]; then
-			return 0
-		fi
+		printf '%s\n' "$artifact_path"
 	done < <(
 		brew info --cask "$cask" 2>/dev/null |
 			awk '
@@ -232,6 +230,30 @@ cask_has_existing_app_artifact() {
 				in_artifacts && / \(App\)$/ { print }
 			'
 	)
+}
+
+cask_has_existing_app_artifact() {
+	local cask="$1"
+	local artifact_path
+
+	while IFS= read -r artifact_path; do
+		if [ -e "$artifact_path" ]; then
+			return 0
+		fi
+	done < <(cask_app_artifact_paths "$cask")
+
+	return 1
+}
+
+cask_has_missing_app_artifact() {
+	local cask="$1"
+	local artifact_path
+
+	while IFS= read -r artifact_path; do
+		if [ ! -e "$artifact_path" ]; then
+			return 0
+		fi
+	done < <(cask_app_artifact_paths "$cask")
 
 	return 1
 }
@@ -312,11 +334,17 @@ install_packages() {
 	local bundle_failed=0
 	local cask
 
-	# Older setup versions removed legacy `.rb` cask receipts. Homebrew sees the
-	# app but cannot manage or upgrade it until the receipt is rebuilt. Repair
-	# both partial Caskroom entries and app-only installs left in /Applications.
+	# Repair incomplete installations that Homebrew's receipt-only checks miss.
 	for cask in $casks; do
 		if brew list --versions --cask "$cask" &>/dev/null; then
+			if ! cask_has_missing_app_artifact "$cask"; then
+				continue
+			fi
+			log "Reinstalling cask with missing application artifact: $cask"
+			if ! brew reinstall --cask --force "$cask"; then
+				log "Warning: Could not restore application artifact for $cask; continuing..."
+				bundle_failed=1
+			fi
 			continue
 		fi
 		if [ -d "$caskroom/$cask" ]; then


### PR DESCRIPTION
Restore app casks when Homebrew has a receipt but any declared application artifact is missing.

## Summary by Sourcery

Repair Homebrew cask installations when declared application artifacts are missing despite an existing receipt.

Bug Fixes:
- Restore missing application artifacts for Homebrew casks that still have installed receipts.
- Detect incomplete multi-application cask installations and reinstall them while avoiding unnecessary reinstalls of complete or non-application casks.

Enhancements:
- Centralize resolution of declared cask application artifact paths for completeness checks.

Tests:
- Verify cask artifact handling across complete, missing, partial multi-application, font-only, renamed, absolute-path, unmanaged-app, and invalid-receipt cases.