### PR TITLE
feat(setup): persist logs and show progress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Setup diagnostics
+
+When investigating a setup failure, inspect the latest private log first:
+
+```bash
+less -R "${XDG_STATE_HOME:-$HOME/.local/state}/profile/setup/latest.log"
+```
+
+If `PROFILE_SETUP_LOG_DIR` was set for the run, use that absolute directory
+instead. Logs may contain local paths or account identifiers. Summarise only
+the relevant evidence and never commit a log.
+
+Follow `CLAUDE.md` for the repository's architecture, workflow, and checks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,20 +14,42 @@ source setup_entry.sh
 
 This detects the OS (`uname`), pulls the latest from `origin/main`, then dispatches to `tools/setup_macos.sh` or `tools/setup_ubuntu.sh`.
 
+Every run writes a private log and prints its path. For diagnostics, inspect the
+latest run first:
+
+```bash
+less -R "${XDG_STATE_HOME:-$HOME/.local/state}/profile/setup/latest.log"
+# During a run:
+tail -f "${XDG_STATE_HOME:-$HOME/.local/state}/profile/setup/latest.log"
+```
+
+Set `PROFILE_SETUP_LOG_DIR` to an absolute path to override the directory.
+Logs and their parent directory are mode `600` and `700` respectively.
+Treat them as private and never commit them.
+
+Each platform's `main` defines its executable function plan. The shared runner
+uses that plan as the progress total and renders a Rich-style bar after each
+setup step.
+
 ## Linting Shell Scripts
 
 ```bash
 shellcheck tools/setup_macos.sh tools/setup_ubuntu.sh tools/common.sh setup_entry.sh
 shfmt -d tools/setup_macos.sh tools/setup_ubuntu.sh tools/common.sh setup_entry.sh
+bash tests/setup_logging/run.sh
+bash tests/setup_progress/run.sh
 ```
 
-There is no test suite.
+Other focused regression scripts are available under `tests/`.
 
 ## Architecture
 
 ### Entry Point Flow
 
-`setup_entry.sh` → OS detection → `tools/setup_macos.sh` or `tools/setup_ubuntu.sh` → both source `tools/common.sh` for shared utilities.
+`setup_entry.sh` → private setup log → OS detection → `tools/setup_macos.sh`
+or `tools/setup_ubuntu.sh` → both source `tools/common.sh` for shared
+utilities. The platform script returns before `setup_entry.sh` closes the log,
+then the entry point starts the replacement login shell.
 
 ### Key Components
 

--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ $ cd ~
 $ git clone https://github.com/alexwilliams0712/profile.git
 $ source setup_entry.sh
 ```
+
+Setup output is stored privately at
+`${XDG_STATE_HOME:-$HOME/.local/state}/profile/setup/latest.log`. Override the
+directory with an absolute `PROFILE_SETUP_LOG_DIR`. The setup shows completed
+steps with a Rich-style progress bar generated from the active platform setup
+functions.

--- a/setup_entry.sh
+++ b/setup_entry.sh
@@ -1,34 +1,162 @@
 #!/bin/bash
 
-sudo -v
+profile_setup_run() {
+	export PROFILE_SETUP_NO_LOGIN_SHELL=1
 
-if [ "$(uname)" = "Darwin" ]; then
-	# setup_macos installs/updates the Command Line Tools after starting the
-	# sudo keepalive. Running softwareupdate here used to happen before that
-	# keepalive and could cause another password prompt later in the setup.
-	:
-elif ! command -v git >/dev/null 2>&1; then
-	echo "git is not installed, installing git."
-	sudo apt-get update
-	sudo apt-get install -y git
-fi
+	sudo -v
 
-# Pull latest version of this repo (non-fatal on first run / auth issues).
-# Apple's /usr/bin/git is only a launcher until the Command Line Tools exist.
-if { [ "$(uname)" != "Darwin" ] || xcode-select -p &>/dev/null; } && GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='ssh -o BatchMode=yes -o ConnectTimeout=10' git fetch origin 2>/dev/null; then
-	git reset --hard origin/main
-	git checkout main
-	GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='ssh -o BatchMode=yes -o ConnectTimeout=10' git pull
-else
-	echo "Warning: could not fetch from remote, continuing with local copy."
-fi
+	if [ "$(uname)" = "Darwin" ]; then
+		# setup_macos installs/updates the Command Line Tools after starting the
+		# sudo keepalive. Running softwareupdate here used to happen before that
+		# keepalive and could cause another password prompt later in the setup.
+		:
+	elif ! command -v git >/dev/null 2>&1; then
+		echo "git is not installed, installing git."
+		sudo apt-get update
+		sudo apt-get install -y git
+	fi
 
-os_name="$(uname)"
+	# Pull latest version of this repo (non-fatal on first run / auth issues).
+	# Apple's /usr/bin/git is only a launcher until the Command Line Tools exist.
+	if { [ "$(uname)" != "Darwin" ] || xcode-select -p &>/dev/null; } && GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='ssh -o BatchMode=yes -o ConnectTimeout=10' git fetch origin 2>/dev/null; then
+		git reset --hard origin/main
+		git checkout main
+		GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='ssh -o BatchMode=yes -o ConnectTimeout=10' git pull
+	else
+		echo "Warning: could not fetch from remote, continuing with local copy."
+	fi
 
-if [ "$os_name" = "Darwin" ]; then
-	bash tools/setup_macos.sh
-elif [ "$os_name" = "Linux" ]; then
-	bash tools/setup_ubuntu.sh
-else
-	source tools/setup_macos.sh
-fi
+	local os_name
+	os_name="$(uname)"
+
+	if [ "$os_name" = "Darwin" ]; then
+		bash tools/setup_macos.sh
+	elif [ "$os_name" = "Linux" ]; then
+		bash tools/setup_ubuntu.sh
+	else
+		# shellcheck disable=SC1091
+		source tools/setup_macos.sh
+	fi
+}
+
+profile_setup_main() {
+	local state_home
+	local log_dir
+	local log_file
+	local status_file
+	local latest_link
+	local timestamp
+	local setup_status
+	local tee_status
+	local had_pipefail=0
+	local output_tty=0
+
+	case "${XDG_STATE_HOME:-}" in
+	/*) state_home="$XDG_STATE_HOME" ;;
+	*) state_home="$HOME/.local/state" ;;
+	esac
+	log_dir="${PROFILE_SETUP_LOG_DIR:-$state_home/profile/setup}"
+	case "$log_dir" in
+	/*) ;;
+	*)
+		printf 'Error: setup log directory must be absolute: %s\n' "$log_dir" >&2
+		unset -f profile_setup_run profile_setup_main
+		return 1
+		;;
+	esac
+
+	if ! timestamp="$(date '+%Y%m%d-%H%M%S')"; then
+		printf 'Error: could not determine the setup log timestamp.\n' >&2
+		unset -f profile_setup_run profile_setup_main
+		return 1
+	fi
+	if ! mkdir -p "$log_dir" || ! chmod 700 "$log_dir"; then
+		printf 'Error: could not prepare setup log directory: %s\n' "$log_dir" >&2
+		unset -f profile_setup_run profile_setup_main
+		return 1
+	fi
+	if [ -d "$log_dir/latest.log" ]; then
+		printf 'Error: latest setup log path is a directory: %s\n' "$log_dir/latest.log" >&2
+		unset -f profile_setup_run profile_setup_main
+		return 1
+	fi
+	if ! log_file="$(umask 077 && mktemp "$log_dir/setup-$timestamp.XXXXXX")" || [ -z "$log_file" ]; then
+		printf 'Error: could not create setup log under: %s\n' "$log_dir" >&2
+		unset -f profile_setup_run profile_setup_main
+		return 1
+	fi
+	latest_link="$log_dir/.latest-${log_file##*/}"
+	if ! chmod 600 "$log_file" ||
+		! ln -s "${log_file##*/}" "$latest_link" ||
+		! mv -f "$latest_link" "$log_dir/latest.log"; then
+		printf 'Error: could not create setup log under: %s\n' "$log_dir" >&2
+		rm -f "$latest_link"
+		unset -f profile_setup_run profile_setup_main
+		return 1
+	fi
+
+	if ! printf 'Setup log: %s\n' "$log_file" | tee -a "$log_file"; then
+		printf 'Error: could not write setup log: %s\n' "$log_file" >&2
+		unset -f profile_setup_run profile_setup_main
+		return 1
+	fi
+
+	if ! status_file="$(umask 077 && mktemp "$log_dir/.setup-status.XXXXXX")" ||
+		[ -z "$status_file" ] || ! chmod 600 "$status_file"; then
+		printf 'Error: could not create setup status under: %s\n' "$log_dir" >&2
+		unset -f profile_setup_run profile_setup_main
+		return 1
+	fi
+	if [ -t 1 ]; then
+		output_tty=1
+	fi
+	if set -o | grep -Eq '^pipefail[[:space:]]+on$'; then
+		had_pipefail=1
+		set +o pipefail
+	fi
+	if (
+		set +e
+		export PROFILE_SETUP_OUTPUT_TTY="$output_tty"
+		profile_setup_run
+		setup_status=$?
+		printf '%s\n' "$setup_status" >"$status_file"
+		exit "$setup_status"
+	) 2>&1 | tee -a "$log_file"; then
+		tee_status=0
+	else
+		tee_status=$?
+	fi
+	if [ "$had_pipefail" -eq 1 ]; then
+		set -o pipefail
+	fi
+	if ! IFS= read -r setup_status <"$status_file"; then
+		setup_status=1
+	fi
+	rm -f "$status_file"
+	case "$setup_status" in
+	'' | *[!0-9]*) setup_status=1 ;;
+	esac
+
+	if [ "$tee_status" -ne 0 ]; then
+		printf 'Error: could not finish writing setup log: %s\n' "$log_file" >&2
+		if [ "$setup_status" -eq 0 ]; then
+			setup_status="$tee_status"
+		fi
+	fi
+	if ! printf 'Setup log saved to: %s\n' "$log_file" | tee -a "$log_file"; then
+		printf 'Error: could not finish writing setup log: %s\n' "$log_file" >&2
+		if [ "$setup_status" -eq 0 ]; then
+			setup_status=1
+		fi
+	fi
+
+	unset -f profile_setup_run profile_setup_main
+	if [ "$setup_status" -ne 0 ]; then
+		return "$setup_status"
+	fi
+
+	# Start the replacement login shell only after tee has closed the log.
+	bash -l
+}
+
+profile_setup_main

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -3,6 +3,12 @@
 Patterns to follow (and mistakes to avoid) when editing the setup scripts.
 Update this file whenever a correction reveals a rule worth keeping.
 
+## Progress presentation
+
+Use a bright-green Rich-style bar for shared terminal setup progress on both
+platforms. Do not apply the Nova UI palette to this terminal output unless Alex
+explicitly asks for it.
+
 ## Where a new install goes
 
 Decide by whether the *exact same commands* work on both macOS and Ubuntu:

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -19,8 +19,8 @@
 - [x] Removed existing Git email and phone values from the persisted prompts.
 - [x] Defined the platform function plans once, then used them for both
 	  execution and shared progress totals: macOS 21 and Ubuntu 43.
-- [x] Added Nova-coloured Unicode progress for interactive UTF-8 terminals and
-      stable ASCII/no-colour output for non-interactive runs.
+- [x] Added bright-green Rich-style Unicode progress for interactive UTF-8
+      terminals and stable ASCII/no-colour output for non-interactive runs.
 - [x] Verified executed, Bash-sourced, and Zsh-sourced logging; stdout/stderr,
       failure status, modes, sequential logs, latest pointer, and caller state.
 - [x] Verified progress phases, success/failure advancement, final setup status,

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,34 @@
+# Persist setup logs for diagnostics
+
+- [x] Capture the complete entry-point and platform setup output without
+      redirecting the caller after `source setup_entry.sh` returns.
+- [x] Store private timestamped logs under the XDG state directory and maintain
+      a stable `latest.log` symlink.
+- [x] End logging before the platform setup hands off to a login shell.
+- [x] Document the log location and override for users and future agents.
+- [x] Show shared Rich-style progress for the actual macOS and Ubuntu setup
+      functions, including completed count, total, and percentage.
+- [x] Add focused source/execute, stream, status, permission, and symlink tests.
+- [x] Add focused progress counting, rendering, and success/failure tests.
+- [x] Run shell checks and obtain an independent review.
+
+## Review
+
+- [x] Added private timestamped logs with an atomic `latest.log` pointer,
+      exact producer status capture, and a login-shell hand-off after logging.
+- [x] Removed existing Git email and phone values from the persisted prompts.
+- [x] Defined the platform function plans once, then used them for both
+	  execution and shared progress totals: macOS 21 and Ubuntu 43.
+- [x] Added Nova-coloured Unicode progress for interactive UTF-8 terminals and
+      stable ASCII/no-colour output for non-interactive runs.
+- [x] Verified executed, Bash-sourced, and Zsh-sourced logging; stdout/stderr,
+      failure status, modes, sequential logs, latest pointer, and caller state.
+- [x] Verified progress phases, success/failure advancement, final setup status,
+      Unicode/ASCII rendering, syntax, formatting, and existing focused tests.
+- [x] Independent review found and verified fixes for completed-bar rendering,
+      directory-shaped latest pointers, inherited shell options, and the fresh
+      macOS preflight count. The final review reported no remaining findings.
+
 # Repair missing Homebrew cask applications
 
 - [x] Reproduce the stale-receipt state where Homebrew reports a cask installed

--- a/tests/setup_logging/run.sh
+++ b/tests/setup_logging/run.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+entry="$repo_root/setup_entry.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+
+printf '%s\n' \
+	'#!/bin/bash' \
+	'printf "sudo called\\n"' \
+	'exit 0' >"$tmp/bin/sudo"
+printf '%s\n' \
+	'#!/bin/bash' \
+	'printf "Darwin\\n"' >"$tmp/bin/uname"
+printf '%s\n' \
+	'#!/bin/bash' \
+	'exit 1' >"$tmp/bin/xcode-select"
+printf '%s\n' \
+	'#!/bin/bash' \
+	'printf "FAIL: git must not run\\n" >&2' \
+	'exit 99' >"$tmp/bin/git"
+# shellcheck disable=SC2016
+printf '%s\n' \
+	'#!/bin/bash' \
+	'case "${1:-}" in' \
+	'tools/setup_macos.sh)' \
+	'	printf "platform stdout\\n"' \
+	'	printf "platform stderr\\n" >&2' \
+	'	exit "${PROFILE_TEST_CHILD_STATUS:-0}"' \
+	'	;;' \
+	'-l)' \
+	'	printf "LOGIN_SHELL_AFTER_LOG\\n"' \
+	'	exit 0' \
+	'	;;' \
+	'esac' \
+	'printf "FAIL: unexpected bash arguments: %s\\n" "$*" >&2' \
+	'exit 98' >"$tmp/bin/bash"
+chmod +x "$tmp/bin/"*
+
+assert_contains() {
+	local value="$1"
+	local expected="$2"
+
+	if [[ "$value" == *"$expected"* ]]; then
+		return
+	fi
+	printf 'FAIL: expected output to contain %q\n%s\n' "$expected" "$value"
+	exit 1
+}
+
+assert_not_contains() {
+	local value="$1"
+	local unexpected="$2"
+
+	if [[ "$value" != *"$unexpected"* ]]; then
+		return
+	fi
+	printf 'FAIL: expected output not to contain %q\n%s\n' "$unexpected" "$value"
+	exit 1
+}
+
+file_mode() {
+	stat -f '%Lp' "$1" 2>/dev/null || stat -c '%a' "$1"
+}
+
+log_dir="$tmp/log dir"
+source_output="$(
+	PATH="$tmp/bin:$PATH" \
+		PROFILE_SETUP_LOG_DIR="$log_dir" \
+		PROFILE_TEST_CHILD_STATUS=0 \
+		/bin/bash -c '
+			set -e
+			set -o pipefail
+			before_pwd="$PWD"
+			before_options="$-"
+			before_pipefail="$(set -o | grep "^pipefail")"
+			before_umask="$(umask)"
+			trap ":" USR1
+			before_trap="$(trap -p USR1)"
+			source "$1"
+			source_status=$?
+			if [ "$PWD" = "$before_pwd" ] &&
+				[ "$-" = "$before_options" ] &&
+				[ "$(set -o | grep "^pipefail")" = "$before_pipefail" ] &&
+				[ "$(umask)" = "$before_umask" ] &&
+				[ "$(trap -p USR1)" = "$before_trap" ] &&
+				! declare -F profile_setup_main >/dev/null &&
+				! declare -F profile_setup_run >/dev/null; then
+				printf "CALLER_STATE_OK\\n"
+			fi
+			printf "SOURCE_STATUS=%s\\n" "$source_status"
+			printf "CALLER_AFTER\\n"
+		' _ "$entry" 2>&1
+)"
+
+assert_contains "$source_output" "platform stdout"
+assert_contains "$source_output" "platform stderr"
+assert_contains "$source_output" "LOGIN_SHELL_AFTER_LOG"
+assert_contains "$source_output" "CALLER_STATE_OK"
+assert_contains "$source_output" "SOURCE_STATUS=0"
+assert_contains "$source_output" "CALLER_AFTER"
+assert_not_contains "$source_output" "FAIL:"
+
+if [ "$(file_mode "$log_dir")" != 700 ]; then
+	printf 'FAIL: log directory mode is %s\n' "$(file_mode "$log_dir")"
+	exit 1
+fi
+if [ ! -L "$log_dir/latest.log" ]; then
+	printf '%s\n' 'FAIL: latest.log is not a symlink'
+	exit 1
+fi
+first_log="$log_dir/$(readlink "$log_dir/latest.log")"
+if [ ! -f "$first_log" ] || [ "$(file_mode "$first_log")" != 600 ]; then
+	printf '%s\n' 'FAIL: first log is absent or not mode 600'
+	exit 1
+fi
+first_contents="$(<"$first_log")"
+assert_contains "$first_contents" "platform stdout"
+assert_contains "$first_contents" "platform stderr"
+assert_not_contains "$first_contents" "LOGIN_SHELL_AFTER_LOG"
+assert_not_contains "$first_contents" "CALLER_AFTER"
+
+if [ -x /bin/zsh ]; then
+	zsh_log_dir="$tmp/zsh logs"
+	zsh_output="$(
+		PATH="$tmp/bin:$PATH" \
+			PROFILE_SETUP_LOG_DIR="$zsh_log_dir" \
+			PROFILE_TEST_CHILD_STATUS=0 \
+			/bin/zsh -c '
+				source "$1"
+				printf "SOURCE_STATUS=%s\\n" "$?"
+				printf "ZSH_CALLER_AFTER\\n"
+			' _ "$entry" 2>&1
+	)"
+	assert_contains "$zsh_output" "SOURCE_STATUS=0"
+	assert_contains "$zsh_output" "LOGIN_SHELL_AFTER_LOG"
+	assert_contains "$zsh_output" "ZSH_CALLER_AFTER"
+	zsh_log="$zsh_log_dir/$(readlink "$zsh_log_dir/latest.log")"
+	zsh_contents="$(<"$zsh_log")"
+	assert_not_contains "$zsh_contents" "LOGIN_SHELL_AFTER_LOG"
+	assert_not_contains "$zsh_contents" "ZSH_CALLER_AFTER"
+fi
+
+failure_output="$(
+	PATH="$tmp/bin:$PATH" \
+		PROFILE_SETUP_LOG_DIR="$log_dir" \
+		PROFILE_TEST_CHILD_STATUS=23 \
+		/bin/bash -c '
+			source "$1"
+			printf "SOURCE_STATUS=%s\\n" "$?"
+			printf "CALLER_AFTER_FAILURE\\n"
+		' _ "$entry" 2>&1
+)"
+assert_contains "$failure_output" "SOURCE_STATUS=23"
+assert_contains "$failure_output" "CALLER_AFTER_FAILURE"
+assert_not_contains "$failure_output" "LOGIN_SHELL_AFTER_LOG"
+second_log="$log_dir/$(readlink "$log_dir/latest.log")"
+if [ "$second_log" = "$first_log" ] || [ ! -f "$first_log" ] || [ ! -f "$second_log" ]; then
+	printf '%s\n' 'FAIL: latest.log did not advance while retaining the first log'
+	exit 1
+fi
+
+errexit_log_dir="$tmp/errexit logs"
+set +e
+errexit_output="$(
+	PATH="$tmp/bin:$PATH" \
+		PROFILE_SETUP_LOG_DIR="$errexit_log_dir" \
+		PROFILE_TEST_CHILD_STATUS=23 \
+		/bin/bash -e -o pipefail -c 'source "$1"' _ "$entry" 2>&1
+)"
+errexit_status=$?
+set -e
+if [ "$errexit_status" -ne 23 ]; then
+	printf 'FAIL: source under errexit returned %s instead of 23\n%s\n' "$errexit_status" "$errexit_output"
+	exit 1
+fi
+assert_contains "$errexit_output" "platform stderr"
+assert_not_contains "$errexit_output" "LOGIN_SHELL_AFTER_LOG"
+assert_not_contains "$errexit_output" "could not finish writing setup log"
+
+execute_log_dir="$tmp/executed logs"
+set +e
+execute_output="$(
+	PATH="$tmp/bin:$PATH" \
+		PROFILE_SETUP_LOG_DIR="$execute_log_dir" \
+		PROFILE_TEST_CHILD_STATUS=0 \
+		/bin/bash "$entry" 2>&1
+)"
+execute_status=$?
+set -e
+if [ "$execute_status" -ne 0 ]; then
+	printf 'FAIL: executed entry point returned %s\n%s\n' "$execute_status" "$execute_output"
+	exit 1
+fi
+assert_contains "$execute_output" "platform stdout"
+assert_contains "$execute_output" "platform stderr"
+assert_contains "$execute_output" "LOGIN_SHELL_AFTER_LOG"
+execute_log="$execute_log_dir/$(readlink "$execute_log_dir/latest.log")"
+execute_contents="$(<"$execute_log")"
+assert_not_contains "$execute_contents" "LOGIN_SHELL_AFTER_LOG"
+
+blocked_log_dir="$tmp/blocked logs"
+mkdir -p "$blocked_log_dir/latest.log"
+blocked_output="$(
+	PATH="$tmp/bin:$PATH" \
+		PROFILE_SETUP_LOG_DIR="$blocked_log_dir" \
+		PROFILE_TEST_CHILD_STATUS=0 \
+		/bin/bash -c '
+			source "$1"
+			printf "SOURCE_STATUS=%s\\n" "$?"
+		' _ "$entry" 2>&1
+)"
+assert_contains "$blocked_output" "latest setup log path is a directory"
+assert_contains "$blocked_output" "SOURCE_STATUS=1"
+assert_not_contains "$blocked_output" "platform stdout"
+assert_not_contains "$blocked_output" "LOGIN_SHELL_AFTER_LOG"
+if [ ! -d "$blocked_log_dir/latest.log" ]; then
+	printf '%s\n' 'FAIL: existing latest.log directory was modified'
+	exit 1
+fi
+if find "$blocked_log_dir" -name 'setup-*' -print -quit | grep -q .; then
+	printf '%s\n' 'FAIL: blocked log directory contains an orphan run log'
+	exit 1
+fi
+
+linked_log_dir="$tmp/linked logs"
+mkdir -p "$linked_log_dir/archive"
+ln -s archive "$linked_log_dir/latest.log"
+linked_output="$(
+	PATH="$tmp/bin:$PATH" \
+		PROFILE_SETUP_LOG_DIR="$linked_log_dir" \
+		PROFILE_TEST_CHILD_STATUS=0 \
+		/bin/bash -c '
+			source "$1"
+			printf "SOURCE_STATUS=%s\\n" "$?"
+		' _ "$entry" 2>&1
+)"
+assert_contains "$linked_output" "latest setup log path is a directory"
+assert_contains "$linked_output" "SOURCE_STATUS=1"
+if [ ! -L "$linked_log_dir/latest.log" ] ||
+	[ "$(readlink "$linked_log_dir/latest.log")" != archive ] ||
+	find "$linked_log_dir/archive" -mindepth 1 -print -quit | grep -q .; then
+	printf '%s\n' 'FAIL: symlinked latest.log directory was modified'
+	exit 1
+fi
+
+printf '%s\n' 'PASS: setup logs are private, complete, discoverable, and bounded'

--- a/tests/setup_progress/run.sh
+++ b/tests/setup_progress/run.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+
+# shellcheck disable=SC1091
+source "$repo_root/tools/common.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+first_step() {
+	:
+}
+
+second_step() {
+	return 7
+}
+
+export NO_COLOR=1
+export PATH="/usr/bin:/bin"
+export PROFILE_SETUP_OUTPUT_TTY=1
+export LC_ALL="C.UTF-8"
+failed_functions=()
+first_phase=(first_step)
+second_phase=(second_step)
+setup_progress_start "${first_phase[@]}" "${second_phase[@]}"
+output_file="$tmp/progress-output"
+{
+	run_functions "${first_phase[@]}"
+	printf '%s\n' 'PARENT_HOOK'
+	run_functions "${second_phase[@]}"
+} >"$output_file" 2>&1
+output="$(<"$output_file")"
+
+if [[ "$output" != *"50% 1/2 ✓ first_step"* ]]; then
+	printf 'FAIL: first progress update is missing\n%s\n' "$output"
+	exit 1
+fi
+if [[ "$output" != *"100% 2/2 ✗ second_step"* ]]; then
+	printf 'FAIL: final progress update is missing\n%s\n' "$output"
+	exit 1
+fi
+final_progress="$(printf '%s\n' "$output" | grep '100% 2/2')"
+if [[ "$final_progress" == *"╺"* ]]; then
+	printf 'FAIL: completed progress bar still has a continuation marker\n%s\n' "$final_progress"
+	exit 1
+fi
+if [[ "$output" != *"━"* ]]; then
+	printf 'FAIL: Rich-style progress bar is missing\n%s\n' "$output"
+	exit 1
+fi
+if [[ "$output" != *"first_step"*"PARENT_HOOK"*"second_step"* ]]; then
+	printf 'FAIL: phased execution order changed\n%s\n' "$output"
+	exit 1
+fi
+if [ "${failed_functions[*]}" != second_step ]; then
+	printf 'FAIL: failed function tracking changed: %s\n' "${failed_functions[*]}"
+	exit 1
+fi
+
+export PROFILE_SETUP_NO_LOGIN_SHELL=1
+export PROFILE_DIR="$tmp"
+set +e
+exit_script >"$tmp/exit-output" 2>&1
+setup_status=$?
+set -e
+if [ "$setup_status" -ne 1 ]; then
+	printf 'FAIL: failed setup status was %s instead of 1\n' "$setup_status"
+	exit 1
+fi
+
+export PROFILE_SETUP_OUTPUT_TTY=0
+export LC_ALL=C
+failed_functions=()
+setup_progress_start first_step
+ascii_output="$(run_function first_step 2>&1)"
+if [[ "$ascii_output" != *"100% 1/1 OK first_step"* ]] ||
+	[[ "$ascii_output" != *"="* ]] ||
+	[[ "$ascii_output" == *"━"* ]] ||
+	[[ "$ascii_output" == *"✓"* ]] ||
+	[[ "$ascii_output" == *$'\033'* ]]; then
+	printf 'FAIL: non-interactive progress fallback is unstable\n%s\n' "$ascii_output"
+	exit 1
+fi
+
+printf '%s\n' 'PASS: progress plans, phases, failures, and rendering work'

--- a/tests/setup_progress/run.sh
+++ b/tests/setup_progress/run.sh
@@ -71,6 +71,17 @@ if [ "$setup_status" -ne 1 ]; then
 	exit 1
 fi
 
+unset NO_COLOR
+export TERM=xterm-256color
+failed_functions=()
+setup_progress_start first_step
+colour_output="$(run_function first_step 2>&1)"
+if [[ "$colour_output" != *$'\033[1;92m'"━"* ]] ||
+	[[ "$colour_output" == *$'\033[38;2;'* ]]; then
+	printf 'FAIL: interactive progress is not Rich-style bright green\n%s\n' "$colour_output"
+	exit 1
+fi
+
 export PROFILE_SETUP_OUTPUT_TTY=0
 export LC_ALL=C
 failed_functions=()

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -85,10 +85,10 @@ setup_progress_advance() {
 	local remaining_bar=""
 	local head=""
 	local symbol="OK"
-	local nova_accent=""
-	local nova_grid=""
-	local nova_status=""
-	local nova_reset=""
+	local bar_colour=""
+	local remaining_colour=""
+	local status_colour=""
+	local colour_reset=""
 	local output_tty="${PROFILE_SETUP_OUTPUT_TTY:-}"
 	local locale="${LC_ALL:-${LC_CTYPE:-${LANG:-}}}"
 	local completed_char="="
@@ -145,20 +145,20 @@ setup_progress_advance() {
 		fi
 	fi
 	if [ "$output_tty" -eq 1 ] && [ "${TERM:-dumb}" != dumb ] && [ -z "${NO_COLOR:-}" ]; then
-		nova_accent=$'\033[38;2;108;142;168m'
-		nova_grid=$'\033[38;2;188;191;185m'
-		nova_reset=$'\033[0m'
+		bar_colour=$'\033[1;92m'
+		remaining_colour=$'\033[90m'
+		colour_reset=$'\033[0m'
 		if [ "$exit_code" -eq 0 ]; then
-			nova_status=$'\033[38;2;155;179;150m'
+			status_colour="$bar_colour"
 		else
-			nova_status=$'\033[38;2;237;158;152m'
+			status_colour=$'\033[1;91m'
 		fi
 	fi
 
 	printf '  %b%s%s%b%s%b %3d%% %d/%d %b%s%b %s\n' \
-		"$nova_accent" "$completed_bar" "$head" "$nova_grid" "$remaining_bar" \
-		"$nova_reset" "$percent" "$SETUP_PROGRESS_CURRENT" "$SETUP_PROGRESS_TOTAL" \
-		"$nova_status" "$symbol" "$nova_reset" "$label"
+		"$bar_colour" "$completed_bar" "$head" "$remaining_colour" "$remaining_bar" \
+		"$colour_reset" "$percent" "$SETUP_PROGRESS_CURRENT" "$SETUP_PROGRESS_TOTAL" \
+		"$status_colour" "$symbol" "$colour_reset" "$label"
 }
 
 # Evaluate the Homebrew shellenv matching the current architecture.

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -15,7 +15,7 @@ handle_error() {
 #   and the background loop's commands can't abort the parent shell.
 # - The loop exits on its own once the parent script ($$) is gone, is killed by
 #   the EXIT trap on error/early-exit paths, and is killed explicitly by
-#   exit_script before its `exec bash -l` (which would otherwise bypass EXIT).
+#   exit_script before it returns or replaces the setup process.
 SUDO_KEEPALIVE_PID=""
 keep_sudo_alive() {
 	# Already running? Do nothing.
@@ -57,6 +57,110 @@ ensure_directory() {
 	cd $PROFILE_DIR
 }
 
+SETUP_PROGRESS_CURRENT=0
+SETUP_PROGRESS_TOTAL=0
+
+setup_progress_start() {
+	SETUP_PROGRESS_CURRENT=0
+	SETUP_PROGRESS_TOTAL="$#"
+}
+
+run_functions() {
+	local func_name
+
+	for func_name in "$@"; do
+		run_function "$func_name"
+	done
+}
+
+setup_progress_advance() {
+	local label="$1"
+	local exit_code="$2"
+	local width=28
+	local filled
+	local remaining
+	local percent
+	local ix
+	local completed_bar=""
+	local remaining_bar=""
+	local head=""
+	local symbol="OK"
+	local nova_accent=""
+	local nova_grid=""
+	local nova_status=""
+	local nova_reset=""
+	local output_tty="${PROFILE_SETUP_OUTPUT_TTY:-}"
+	local locale="${LC_ALL:-${LC_CTYPE:-${LANG:-}}}"
+	local completed_char="="
+	local remaining_char="-"
+	local head_char=">"
+	local unicode_output=0
+
+	if [ "$SETUP_PROGRESS_TOTAL" -le 0 ]; then
+		return
+	fi
+	SETUP_PROGRESS_CURRENT=$((SETUP_PROGRESS_CURRENT + 1))
+	filled=$((SETUP_PROGRESS_CURRENT * width / SETUP_PROGRESS_TOTAL))
+	percent=$((SETUP_PROGRESS_CURRENT * 100 / SETUP_PROGRESS_TOTAL))
+	remaining=$((width - filled))
+	if [ "$SETUP_PROGRESS_CURRENT" -lt "$SETUP_PROGRESS_TOTAL" ]; then
+		head="$head_char"
+		remaining=$((remaining - 1))
+	fi
+	if [ -z "$output_tty" ]; then
+		if [ -t 1 ]; then
+			output_tty=1
+		else
+			output_tty=0
+		fi
+	fi
+	case "$locale" in
+	*[Uu][Tt][Ff]-8* | *[Uu][Tt][Ff]8*)
+		if [ "$output_tty" -eq 1 ]; then
+			unicode_output=1
+			completed_char="━"
+			remaining_char="━"
+			head_char="╺"
+			if [ "$SETUP_PROGRESS_CURRENT" -lt "$SETUP_PROGRESS_TOTAL" ]; then
+				head="$head_char"
+			fi
+		fi
+		;;
+	esac
+	for ((ix = 0; ix < filled; ix++)); do
+		completed_bar+="$completed_char"
+	done
+	for ((ix = 0; ix < remaining; ix++)); do
+		remaining_bar+="$remaining_char"
+	done
+
+	if [ "$exit_code" -ne 0 ]; then
+		symbol="FAIL"
+	fi
+	if [ "$unicode_output" -eq 1 ]; then
+		if [ "$exit_code" -eq 0 ]; then
+			symbol="✓"
+		else
+			symbol="✗"
+		fi
+	fi
+	if [ "$output_tty" -eq 1 ] && [ "${TERM:-dumb}" != dumb ] && [ -z "${NO_COLOR:-}" ]; then
+		nova_accent=$'\033[38;2;108;142;168m'
+		nova_grid=$'\033[38;2;188;191;185m'
+		nova_reset=$'\033[0m'
+		if [ "$exit_code" -eq 0 ]; then
+			nova_status=$'\033[38;2;155;179;150m'
+		else
+			nova_status=$'\033[38;2;237;158;152m'
+		fi
+	fi
+
+	printf '  %b%s%s%b%s%b %3d%% %d/%d %b%s%b %s\n' \
+		"$nova_accent" "$completed_bar" "$head" "$nova_grid" "$remaining_bar" \
+		"$nova_reset" "$percent" "$SETUP_PROGRESS_CURRENT" "$SETUP_PROGRESS_TOTAL" \
+		"$nova_status" "$symbol" "$nova_reset" "$label"
+}
+
 # Evaluate the Homebrew shellenv matching the current architecture.
 # Apple Silicon native uses /opt/homebrew, Rosetta/Intel uses /usr/local;
 # fall back to the other prefix if the preferred one isn't present.
@@ -75,13 +179,13 @@ collect_user_input() {
 	GIT_USER_PHONE=$(git config --global user.phonenumber 2>/dev/null) || GIT_USER_PHONE=""
 
 	if [ -z "$GIT_USER_NAME" ]; then
-		read -p "Enter github username: " GIT_USER_NAME
+		read -r -p "Enter github username: " GIT_USER_NAME
 	fi
-	read -p "Enter github email address (leave blank to keep '$GIT_USER_EMAIL'): " input
+	read -r -p "Enter github email address (leave blank to keep the existing value): " input
 	if [ ! -z "$input" ]; then
 		GIT_USER_EMAIL="$input"
 	fi
-	read -p "Enter phone number (leave blank to keep '$GIT_USER_PHONE'): " input
+	read -r -p "Enter phone number (leave blank to keep the existing value): " input
 	if [ ! -z "$input" ]; then
 		GIT_USER_PHONE="$input"
 	fi
@@ -133,6 +237,7 @@ run_function() {
 	else
 		echo "<<< $func_name done"
 	fi
+	setup_progress_advance "$func_name" "$exit_code"
 }
 
 set_git_config() {
@@ -351,8 +456,8 @@ install_ai() {
 
 exit_script() {
 	print_function_name
-	# Stop the sudo keepalive explicitly: the `exec bash -l` below replaces this
-	# process, so the EXIT trap would never fire to reap it otherwise.
+	local setup_status=0
+	# Stop the sudo keepalive explicitly before returning or replacing this process.
 	[ -n "$SUDO_KEEPALIVE_PID" ] && kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
 	ensure_directory
 	if [ ${#failed_functions[@]} -eq 0 ]; then
@@ -363,6 +468,13 @@ exit_script() {
 		echo "==============================="
 		echo "       Setup Failed            "
 		echo "==============================="
+		setup_status=1
+	fi
+	if [ "${PROFILE_SETUP_NO_LOGIN_SHELL:-0}" = 1 ]; then
+		return "$setup_status"
+	fi
+	if [ "$setup_status" -ne 0 ]; then
+		return "$setup_status"
 	fi
 	exec bash -l
 }

--- a/tools/setup_macos.sh
+++ b/tools/setup_macos.sh
@@ -645,43 +645,54 @@ main() {
 	# A fresh mac needs CLT before git can read the existing identity. On a
 	# configured mac, collect the two optional values first, then check updates.
 	local clt_was_missing=false
+	local preflight_steps=(install_command_line_tools)
+	local before_brew_steps=(
+		copy_dotfiles
+		set_git_config
+		install_homebrew
+	)
+	local after_brew_steps=(
+		install_packages
+		setup_bash
+		install_ruby
+		install_pyenv
+		install_rust
+		install_foundry
+		install_node
+		install_go
+		setup_docker
+		setup_vscode
+		install_espanso
+		install_tailscale
+		install_terraform
+		install_starship
+		install_webtools
+		install_syncthing
+		install_ai
+	)
+	failed_functions=()
+	setup_progress_start "${preflight_steps[@]}" "${before_brew_steps[@]}" "${after_brew_steps[@]}"
 	if ! xcode-select -p &>/dev/null; then
 		clt_was_missing=true
-		install_command_line_tools
+		run_functions "${preflight_steps[@]}"
+		# Git cannot read the existing identity until this required preflight succeeds.
+		if [ ${#failed_functions[@]} -ne 0 ]; then
+			return 1
+		fi
 	fi
 
 	collect_user_input
 
-	failed_functions=()
 	if [ "$clt_was_missing" = false ]; then
-		run_function install_command_line_tools
+		before_brew_steps=("${preflight_steps[@]}" "${before_brew_steps[@]}")
 	fi
-
-	run_function copy_dotfiles
-	run_function set_git_config
-	run_function install_homebrew
+	run_functions "${before_brew_steps[@]}"
 	# run_function isolates each step so errors are reliable. Refresh the
 	# environment changes made by install_homebrew in the parent shell.
 	brew_shellenv
 	export HOMEBREW_NO_AUTO_UPDATE=1
 	export HOMEBREW_NO_INSTALL_FROM_API=0
-	run_function install_packages
-	run_function setup_bash
-	run_function install_ruby
-	run_function install_pyenv
-	run_function install_rust
-	run_function install_foundry
-	run_function install_node
-	run_function install_go
-	run_function setup_docker
-	run_function setup_vscode
-	run_function install_espanso
-	run_function install_tailscale
-	run_function install_terraform
-	run_function install_starship
-	run_function install_webtools
-	run_function install_syncthing
-	run_function install_ai
+	run_functions "${after_brew_steps[@]}"
 
 	# Report failures if any
 	if [ ${#failed_functions[@]} -ne 0 ]; then

--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -981,61 +981,66 @@ main() {
 	collect_user_input
 
 	failed_functions=()
+	local bootstrap_steps=(copy_dotfiles)
+	local remaining_steps=(
+		set_git_config
+		install_apt_packages
+		ssh_stuff
+		configure_remote_unlock
+		install_pyenv
+		install_pg_formatter
+		install_browser
+		install_vscode
+		install_flatpaks
+		install_rust
+		install_foundry
+		install_and_setup_docker
+		install_github_cli
+		install_syncthing
+		install_espanso
+		install_clam_av
+		install_1password
+		install_jetbrains_toolbox
+		install_font
+		btop_install
+		install_slack
+		install_node
+		install_go
+		install_tailscale
+		install_aws_cli
+		install_terraform
+		install_speedtest
+		# install_k3s
+		# install_helm
+		# install_coolercontrol
+		# install_open_rgb_rules
+		webinstalls
+		# install_burpsuite
+		install_starship
+		install_carapace
+		install_viddy
+		install_duf
+		install_gum
+		install_ghostty
+		configure_gnome
+		install_delta
+		install_lazygit
+		install_lazydocker
+		install_dust
+		install_redis_insight
+		install_ai
+		apt_upgrader
+	)
+	setup_progress_start "${bootstrap_steps[@]}" "${remaining_steps[@]}"
 
 	# copy_dotfiles must run first — it sources .bash_aliases which defines apt_upgrader
-	run_function copy_dotfiles
+	run_functions "${bootstrap_steps[@]}"
 	# run_function isolates setup steps so failures cannot be masked. Source the
 	# copied aliases in the parent as well because later steps use apt_upgrader.
 	if [ -f "$HOME/.bash_aliases" ]; then
 		source "$HOME/.bash_aliases"
 	fi
-	run_function set_git_config
-	run_function install_apt_packages
-	run_function ssh_stuff
-	run_function configure_remote_unlock
-	run_function install_pyenv
-	run_function install_pg_formatter
-	run_function install_browser
-	run_function install_vscode
-	run_function install_flatpaks
-	run_function install_rust
-	run_function install_foundry
-	run_function install_and_setup_docker
-	run_function install_github_cli
-	run_function install_syncthing
-	run_function install_espanso
-	run_function install_clam_av
-	run_function install_1password
-	run_function install_jetbrains_toolbox
-	run_function install_font
-	run_function btop_install
-	run_function install_slack
-	run_function install_node
-	run_function install_go
-	run_function install_tailscale
-	run_function install_aws_cli
-	run_function install_terraform
-	run_function install_speedtest
-	# run_function install_k3s
-	# run_function install_helm
-	# run_function install_coolercontrol
-	# run_function install_open_rgb_rules
-	run_function webinstalls
-	# run_function install_burpsuite
-	run_function install_starship
-	run_function install_carapace
-	run_function install_viddy
-	run_function install_duf
-	run_function install_gum
-	run_function install_ghostty
-	run_function configure_gnome
-	run_function install_delta
-	run_function install_lazygit
-	run_function install_lazydocker
-	run_function install_dust
-	run_function install_redis_insight
-	run_function install_ai
-	run_function apt_upgrader
+	run_functions "${remaining_steps[@]}"
 
 	# Report failures if any
 	if [ ${#failed_functions[@]} -ne 0 ]; then


### PR DESCRIPTION
Persist private setup logs with a stable diagnostic path and show shared progress across platform setup steps.

## Summary by Sourcery

Persist private setup diagnostics and provide consistent cross-platform progress reporting while preserving reliable setup behavior.

New Features:
- Persist complete setup output in private timestamped logs with a stable `latest.log` diagnostic path.
- Display shared progress across macOS and Ubuntu setup steps with success and failure status.

Bug Fixes:
- Preserve setup command status and caller shell state when sourcing the entry point, including failures and login-shell handoff.

Enhancements:
- Centralize platform setup plans so execution and progress totals remain consistent.
- Avoid exposing existing Git email and phone values in interactive prompts.

Documentation:
- Document setup log discovery, privacy, override configuration, and progress behavior.

Tests:
- Add focused coverage for setup logging, status propagation, permissions, symlink handling, shell sourcing, and progress rendering.

Chores:
- Add setup diagnostics guidance for investigating failures.