### PR TITLE
fix(setup): stabilise progress and macOS packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,10 @@ setup step.
 ## Linting Shell Scripts
 
 ```bash
-shellcheck tools/setup_macos.sh tools/setup_ubuntu.sh tools/common.sh setup_entry.sh
-shfmt -d tools/setup_macos.sh tools/setup_ubuntu.sh tools/common.sh setup_entry.sh
+shellcheck tools/setup_macos.sh tools/setup_ubuntu.sh tools/common.sh tools/macos_helpers.sh setup_entry.sh
+shfmt -d tools/setup_macos.sh tools/setup_ubuntu.sh tools/common.sh tools/macos_helpers.sh setup_entry.sh
 bash tests/setup_logging/run.sh
+bash tests/setup_macos/run.sh
 bash tests/setup_progress/run.sh
 ```
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -5,9 +5,10 @@ Update this file whenever a correction reveals a rule worth keeping.
 
 ## Progress presentation
 
-Use a bright-green Rich-style bar for shared terminal setup progress on both
-platforms. Do not apply the Nova UI palette to this terminal output unless Alex
-explicitly asks for it.
+Use one in-place, bright-green Rich-style bar for shared interactive terminal
+setup progress on both platforms. Do not emit a new bar line after every step,
+and do not apply the Nova UI palette unless Alex explicitly asks for it. Keep
+newline-based output for non-interactive runs.
 
 ## Where a new install goes
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -49,6 +49,11 @@ For macOS, add the package to `tools/Brewfile` (formula or cask) so
 extra wiring (start a service, link a CLI, copy config). Don't shell out to a
 manual installer on macOS when a maintained formula/cask exists.
 
+Homebrew's negative boolean environment flags are enabled by their presence,
+including when set to `0`. Unset `HOMEBREW_NO_INSTALL_FROM_API` to use the JSON
+API. After untapping `homebrew/core`, inspect installed formulae with one
+unnamed `brew list --formula`; a named lookup can clone the tap again.
+
 ## General conventions (enforced)
 
 - Tabs for indentation in shell scripts (not spaces).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -47,6 +47,28 @@
       directory-shaped latest pointers, inherited shell options, and the fresh
       macOS preflight count. The final review reported no remaining findings.
 
+# Fix monitored macOS package failures
+
+- [x] Reproduce the cask resolution failure from Homebrew's negative API flag.
+- [x] Enable API installs by leaving `HOMEBREW_NO_INSTALL_FROM_API` unset.
+- [x] Validate CLT state after `softwareupdate` and fall back to active Xcode
+      when a stale standalone installation remains.
+- [x] Avoid cloning `homebrew-core` while checking unwanted installed formulae.
+- [x] Add focused regressions and run shell checks.
+- [x] Obtain an independent review and prepare a separate pull request.
+
+## Review
+
+- [x] Confirmed live that setting the negative API flag to `0` breaks cask
+      lookup while leaving it unset resolves the same casks.
+- [x] Added post-update CLT validation with a recoverable stale-directory
+      backup only when full Xcode is valid and sufficient.
+- [x] Covered current, missing, outdated, advisory, stale, Xcode-only, and
+      standalone-required toolchain states with isolated stubs.
+- [x] Verified all focused regressions, syntax, formatting, lint, and the live
+      read-only cask and current-machine predicate checks.
+- [x] Independent final review reported no remaining findings.
+
 # Repair missing Homebrew cask applications
 
 - [x] Reproduce the stale-receipt state where Homebrew reports a cask installed

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,21 @@
+# Render one interactive setup progress bar
+
+- [x] Replace per-step interactive progress lines with one in-place bar.
+- [x] Clear the live bar before setup output and finish it with a newline.
+- [x] Preserve newline-based ASCII progress for non-interactive runs.
+- [x] Add focused rendering regressions and run the shell checks.
+- [x] Obtain an independent review and prepare a follow-up pull request.
+
+## Review
+
+- [x] Interactive progress now redraws one bright-green line, preserves an
+      aggregate failure state, and adapts to narrow UTF-8 and ASCII terminals.
+- [x] Verified adjacent functions, parent-shell hooks, final newlines,
+      non-interactive output, failure ordering, syntax, formatting, and lint.
+- [x] The monitored run completed 20 of 21 functions. `install_packages` failed
+      for separately diagnosed Homebrew API and stale CLT reasons.
+- [x] Independent final review reported no remaining findings.
+
 # Persist setup logs for diagnostics
 
 - [x] Capture the complete entry-point and platform setup output without

--- a/tests/setup_macos/run.sh
+++ b/tests/setup_macos/run.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+
+# shellcheck disable=SC1091
+source "$repo_root/tools/common.sh"
+# shellcheck disable=SC1091
+source "$repo_root/tools/macos_helpers.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+
+# shellcheck disable=SC2016
+printf '%s\n' \
+	'#!/bin/bash' \
+	'if [ "${PROFILE_TEST_BREW_OUTDATED:-0}" = 1 ]; then' \
+	'  printf "Warning: Your Command Line Tools are too outdated.\\n"' \
+	'elif [ "${PROFILE_TEST_BREW_OUTDATED:-0}" = 2 ]; then' \
+	'  printf "Warning: A newer Command Line Tools release is available.\\n"' \
+	'elif [ "${PROFILE_TEST_BREW_OUTDATED:-0}" = 3 ]; then' \
+	'  printf "Error: Xcode alone is not sufficient on this macOS release.\\n"' \
+	'fi' >"$tmp/bin/brew"
+chmod +x "$tmp/bin/brew"
+
+export PATH="$tmp/bin:/usr/bin:/bin"
+
+clt_receipt_exists() {
+	return "${PROFILE_TEST_PKGUTIL_STATUS:-0}"
+}
+
+standalone_command_line_tools_exist() {
+	return "${PROFILE_TEST_CLT_DIR_STATUS:-1}"
+}
+
+move_stale_command_line_tools() {
+	printf 'called\n' >>"$tmp/sudo.log"
+}
+
+available_command_line_tools_label() {
+	printf 'called\n' >>"$tmp/softwareupdate.log"
+	printf '%s\n' 'Command Line Tools fixture'
+}
+
+if grep -q 'HOMEBREW_NO_INSTALL_FROM_API=' "$repo_root/tools/setup_macos.sh" ||
+	! grep -Eq '^unset .*HOMEBREW_NO_INSTALL_FROM_API' "$repo_root/tools/setup_macos.sh"; then
+	printf '%s\n' 'FAIL: Homebrew API opt-out is not unconditionally unset'
+	exit 1
+fi
+if grep -REq 'PROFILE_SETUP_(CLT|PKGUTIL|SUDO)' \
+	"$repo_root/tools/setup_macos.sh" "$repo_root/tools/macos_helpers.sh"; then
+	printf '%s\n' 'FAIL: privileged CLT targets are environment-selectable'
+	exit 1
+fi
+# shellcheck disable=SC2016
+if grep -Fq 'brew list "$pkg"' "$repo_root/tools/setup_macos.sh" ||
+	! grep -Fq 'brew list --formula' "$repo_root/tools/setup_macos.sh"; then
+	printf '%s\n' 'FAIL: unwanted formula checks can re-clone homebrew/core'
+	exit 1
+fi
+
+export PROFILE_TEST_PKGUTIL_STATUS=0
+export PROFILE_TEST_BREW_OUTDATED=0
+if ! command_line_tools_are_current; then
+	printf '%s\n' 'FAIL: current Command Line Tools were rejected'
+	exit 1
+fi
+
+export PROFILE_TEST_PKGUTIL_STATUS=1
+if command_line_tools_are_current; then
+	printf '%s\n' 'FAIL: missing Command Line Tools receipt was accepted'
+	exit 1
+fi
+
+export PROFILE_TEST_PKGUTIL_STATUS=0
+export PROFILE_TEST_BREW_OUTDATED=1
+if command_line_tools_are_current; then
+	printf '%s\n' 'FAIL: outdated Command Line Tools were accepted'
+	exit 1
+fi
+
+export PROFILE_TEST_BREW_OUTDATED=2
+if ! command_line_tools_are_current; then
+	printf '%s\n' 'FAIL: advisory Command Line Tools update was treated as fatal'
+	exit 1
+fi
+
+if command_line_tools_label_if_required false >/dev/null; then
+	printf '%s\n' 'FAIL: optional CLT update unexpectedly returned a label'
+	exit 1
+fi
+if [ -e "$tmp/softwareupdate.log" ]; then
+	printf '%s\n' 'FAIL: optional CLT state invoked softwareupdate listing'
+	exit 1
+fi
+if [ "$(command_line_tools_label_if_required true)" != 'Command Line Tools fixture' ] ||
+	[ "$(wc -l <"$tmp/softwareupdate.log")" -ne 1 ]; then
+	printf '%s\n' 'FAIL: required CLT state did not list updates exactly once'
+	exit 1
+fi
+
+export PROFILE_TEST_BREW_OUTDATED=0
+export PROFILE_TEST_PKGUTIL_STATUS=1
+export PROFILE_TEST_CLT_DIR_STATUS=0
+if ! command_line_tools_update_required true; then
+	printf '%s\n' 'FAIL: stale standalone tools did not request an update'
+	exit 1
+fi
+if ! use_full_xcode_for_invalid_command_line_tools true; then
+	printf '%s\n' 'FAIL: full Xcode did not replace stale standalone tools'
+	exit 1
+fi
+if [ "$(wc -l <"$tmp/sudo.log")" -ne 1 ]; then
+	printf '%s\n' 'FAIL: stale standalone tools were not moved once'
+	exit 1
+fi
+
+if ! command_line_tools_update_required false; then
+	printf '%s\n' 'FAIL: invalid tools without Xcode did not request an update'
+	exit 1
+fi
+if use_full_xcode_for_invalid_command_line_tools false; then
+	printf '%s\n' 'FAIL: invalid standalone tools passed without full Xcode'
+	exit 1
+fi
+if [ "$(wc -l <"$tmp/sudo.log")" -ne 1 ]; then
+	printf '%s\n' 'FAIL: invalid tools were moved without a full Xcode fallback'
+	exit 1
+fi
+
+export PROFILE_TEST_PKGUTIL_STATUS=0
+before_sudo_calls="$(wc -l <"$tmp/sudo.log")"
+if ! use_full_xcode_for_invalid_command_line_tools true; then
+	printf '%s\n' 'FAIL: current standalone tools were rejected'
+	exit 1
+fi
+if [ "$(wc -l <"$tmp/sudo.log")" -ne "$before_sudo_calls" ]; then
+	printf '%s\n' 'FAIL: current standalone tools were modified'
+	exit 1
+fi
+
+export PROFILE_TEST_PKGUTIL_STATUS=1
+export PROFILE_TEST_CLT_DIR_STATUS=1
+before_sudo_calls="$(wc -l <"$tmp/sudo.log")"
+if command_line_tools_update_required true; then
+	printf '%s\n' 'FAIL: Xcode-only state requested another standalone update'
+	exit 1
+fi
+if ! use_full_xcode_for_invalid_command_line_tools true; then
+	printf '%s\n' 'FAIL: full Xcode without standalone tools was rejected'
+	exit 1
+fi
+if [ "$(wc -l <"$tmp/sudo.log")" -ne "$before_sudo_calls" ]; then
+	printf '%s\n' 'FAIL: idempotent full Xcode fallback invoked sudo'
+	exit 1
+fi
+
+export PROFILE_TEST_BREW_OUTDATED=3
+if ! command_line_tools_update_required true; then
+	printf '%s\n' 'FAIL: a mandatory standalone CLT state skipped its update'
+	exit 1
+fi
+if use_full_xcode_for_invalid_command_line_tools true; then
+	printf '%s\n' 'FAIL: full Xcode was accepted when Homebrew requires standalone CLT'
+	exit 1
+fi
+if [ "$(wc -l <"$tmp/sudo.log")" -ne "$before_sudo_calls" ]; then
+	printf '%s\n' 'FAIL: mandatory standalone CLT state moved files before failing'
+	exit 1
+fi
+
+printf '%s\n' 'PASS: Homebrew API and Command Line Tools state are validated'

--- a/tests/setup_progress/run.sh
+++ b/tests/setup_progress/run.sh
@@ -18,10 +18,16 @@ second_step() {
 	return 7
 }
 
+fail_first() {
+	return 9
+}
+
 export NO_COLOR=1
 export PATH="/usr/bin:/bin"
 export PROFILE_SETUP_OUTPUT_TTY=1
 export LC_ALL="C.UTF-8"
+export TERM=xterm-256color
+export COLUMNS=80
 failed_functions=()
 first_phase=(first_step)
 second_phase=(second_step)
@@ -29,6 +35,7 @@ setup_progress_start "${first_phase[@]}" "${second_phase[@]}"
 output_file="$tmp/progress-output"
 {
 	run_functions "${first_phase[@]}"
+	setup_progress_clear
 	printf '%s\n' 'PARENT_HOOK'
 	run_functions "${second_phase[@]}"
 } >"$output_file" 2>&1
@@ -51,6 +58,10 @@ if [[ "$output" != *"━"* ]]; then
 	printf 'FAIL: Rich-style progress bar is missing\n%s\n' "$output"
 	exit 1
 fi
+if [[ "$output" != *"50% 1/2 ✓ first_step"$'\r\033[2K'"PARENT_HOOK"* ]]; then
+	printf 'FAIL: incomplete progress did not redraw in place\n%s\n' "$output"
+	exit 1
+fi
 if [[ "$output" != *"first_step"*"PARENT_HOOK"*"second_step"* ]]; then
 	printf 'FAIL: phased execution order changed\n%s\n' "$output"
 	exit 1
@@ -71,8 +82,46 @@ if [ "$setup_status" -ne 1 ]; then
 	exit 1
 fi
 
+failed_functions=()
+setup_progress_start first_step first_step
+adjacent_output="$(run_functions first_step first_step 2>&1)"
+if [[ "$adjacent_output" != *"50% 1/2 ✓ first_step"$'\r\033[2K'">>> first_step"* ]]; then
+	printf 'FAIL: adjacent function did not clear the live bar\n%s\n' "$adjacent_output"
+	exit 1
+fi
+
+failed_functions=()
+setup_progress_start fail_first first_step
+aggregate_output="$(run_functions fail_first first_step 2>&1)"
+if [[ "$aggregate_output" != *"100% 2/2 ✗ first_step"* ]]; then
+	printf 'FAIL: final progress lost an earlier failure\n%s\n' "$aggregate_output"
+	exit 1
+fi
+
+export COLUMNS=24
+failed_functions=()
+setup_progress_start first_step
+narrow_output="$(run_function first_step 2>&1)"
+narrow_line="$(printf '%s\n' "$narrow_output" | tail -n 1 | LC_ALL=C sed $'s/\033\\[[0-9;]*[A-Za-z]//g; s/\r//g')"
+if [ "${#narrow_line}" -gt "$COLUMNS" ]; then
+	printf 'FAIL: narrow-terminal progress is %d columns wide\n%s\n' "${#narrow_line}" "$narrow_line"
+	exit 1
+fi
+
+export LC_ALL=C
+failed_functions=()
+setup_progress_start second_step
+narrow_ascii_output="$(run_function second_step 2>&1)"
+narrow_ascii_line="$(printf '%s\n' "$narrow_ascii_output" | tail -n 1 | LC_ALL=C sed $'s/\033\\[[0-9;]*[A-Za-z]//g; s/\r//g')"
+if [ "${#narrow_ascii_line}" -gt "$COLUMNS" ]; then
+	printf 'FAIL: narrow ASCII failure progress is %d columns wide\n%s\n' \
+		"${#narrow_ascii_line}" "$narrow_ascii_line"
+	exit 1
+fi
+export COLUMNS=80
+export LC_ALL="C.UTF-8"
+
 unset NO_COLOR
-export TERM=xterm-256color
 failed_functions=()
 setup_progress_start first_step
 colour_output="$(run_function first_step 2>&1)"

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -59,10 +59,22 @@ ensure_directory() {
 
 SETUP_PROGRESS_CURRENT=0
 SETUP_PROGRESS_TOTAL=0
+SETUP_PROGRESS_VISIBLE=0
+SETUP_PROGRESS_FAILED=0
 
 setup_progress_start() {
 	SETUP_PROGRESS_CURRENT=0
 	SETUP_PROGRESS_TOTAL="$#"
+	SETUP_PROGRESS_VISIBLE=0
+	SETUP_PROGRESS_FAILED=0
+}
+
+setup_progress_clear() {
+	if [ "$SETUP_PROGRESS_VISIBLE" -ne 1 ]; then
+		return
+	fi
+	printf '\r\033[2K'
+	SETUP_PROGRESS_VISIBLE=0
 }
 
 run_functions() {
@@ -95,17 +107,24 @@ setup_progress_advance() {
 	local remaining_char="-"
 	local head_char=">"
 	local unicode_output=0
+	local live_output=0
+	local live_label="$label"
+	local compact_output=0
+	local display_status
+	local count
+	local fixed_width
+	local available_width
+	local terminal_columns
+	local progress_line
 
 	if [ "$SETUP_PROGRESS_TOTAL" -le 0 ]; then
 		return
 	fi
 	SETUP_PROGRESS_CURRENT=$((SETUP_PROGRESS_CURRENT + 1))
-	filled=$((SETUP_PROGRESS_CURRENT * width / SETUP_PROGRESS_TOTAL))
 	percent=$((SETUP_PROGRESS_CURRENT * 100 / SETUP_PROGRESS_TOTAL))
-	remaining=$((width - filled))
-	if [ "$SETUP_PROGRESS_CURRENT" -lt "$SETUP_PROGRESS_TOTAL" ]; then
-		head="$head_char"
-		remaining=$((remaining - 1))
+	count="${SETUP_PROGRESS_CURRENT}/${SETUP_PROGRESS_TOTAL}"
+	if [ "$exit_code" -ne 0 ]; then
+		SETUP_PROGRESS_FAILED=1
 	fi
 	if [ -z "$output_tty" ]; then
 		if [ -t 1 ]; then
@@ -114,6 +133,9 @@ setup_progress_advance() {
 			output_tty=0
 		fi
 	fi
+	if [ "$output_tty" -eq 1 ] && [ "${TERM:-dumb}" != dumb ]; then
+		live_output=1
+	fi
 	case "$locale" in
 	*[Uu][Tt][Ff]-8* | *[Uu][Tt][Ff]8*)
 		if [ "$output_tty" -eq 1 ]; then
@@ -121,12 +143,50 @@ setup_progress_advance() {
 			completed_char="━"
 			remaining_char="━"
 			head_char="╺"
-			if [ "$SETUP_PROGRESS_CURRENT" -lt "$SETUP_PROGRESS_TOTAL" ]; then
-				head="$head_char"
-			fi
 		fi
 		;;
 	esac
+	display_status="$exit_code"
+	if [ "$live_output" -eq 1 ]; then
+		display_status="$SETUP_PROGRESS_FAILED"
+	fi
+	if [ "$display_status" -ne 0 ]; then
+		symbol="FAIL"
+	fi
+	if [ "$unicode_output" -eq 1 ]; then
+		if [ "$display_status" -eq 0 ]; then
+			symbol="✓"
+		else
+			symbol="✗"
+		fi
+	fi
+	if [ "$live_output" -eq 1 ]; then
+		terminal_columns="${COLUMNS:-}"
+		case "$terminal_columns" in
+		'' | *[!0-9]* | 0) terminal_columns="$(tput cols 2>/dev/null || printf '80')" ;;
+		esac
+		fixed_width=$((9 + ${#count} + ${#symbol}))
+		if [ "$terminal_columns" -lt $((fixed_width + width + 1 + ${#live_label})) ]; then
+			live_label=""
+		fi
+		available_width=$((terminal_columns - fixed_width))
+		if [ -z "$live_label" ] && [ "$available_width" -lt "$width" ]; then
+			width="$available_width"
+		fi
+		if [ "$width" -lt 1 ]; then
+			compact_output=1
+			width=$((terminal_columns - ${#count} - 1))
+			if [ "$width" -lt 1 ]; then
+				width=1
+			fi
+		fi
+	fi
+	filled=$((SETUP_PROGRESS_CURRENT * width / SETUP_PROGRESS_TOTAL))
+	remaining=$((width - filled))
+	if [ "$SETUP_PROGRESS_CURRENT" -lt "$SETUP_PROGRESS_TOTAL" ]; then
+		head="$head_char"
+		remaining=$((remaining - 1))
+	fi
 	for ((ix = 0; ix < filled; ix++)); do
 		completed_bar+="$completed_char"
 	done
@@ -134,31 +194,41 @@ setup_progress_advance() {
 		remaining_bar+="$remaining_char"
 	done
 
-	if [ "$exit_code" -ne 0 ]; then
-		symbol="FAIL"
-	fi
-	if [ "$unicode_output" -eq 1 ]; then
-		if [ "$exit_code" -eq 0 ]; then
-			symbol="✓"
-		else
-			symbol="✗"
-		fi
-	fi
 	if [ "$output_tty" -eq 1 ] && [ "${TERM:-dumb}" != dumb ] && [ -z "${NO_COLOR:-}" ]; then
 		bar_colour=$'\033[1;92m'
 		remaining_colour=$'\033[90m'
 		colour_reset=$'\033[0m'
-		if [ "$exit_code" -eq 0 ]; then
+		if [ "$display_status" -eq 0 ]; then
 			status_colour="$bar_colour"
 		else
 			status_colour=$'\033[1;91m'
 		fi
 	fi
-
-	printf '  %b%s%s%b%s%b %3d%% %d/%d %b%s%b %s\n' \
-		"$bar_colour" "$completed_bar" "$head" "$remaining_colour" "$remaining_bar" \
-		"$colour_reset" "$percent" "$SETUP_PROGRESS_CURRENT" "$SETUP_PROGRESS_TOTAL" \
-		"$status_colour" "$symbol" "$colour_reset" "$label"
+	if [ "$compact_output" -eq 1 ]; then
+		printf -v progress_line '%b%s%s%b%s%b %s' \
+			"$bar_colour" "$completed_bar" "$head" "$remaining_colour" "$remaining_bar" \
+			"$colour_reset" "$count"
+	elif [ "$live_output" -eq 1 ] && [ -z "$live_label" ]; then
+		printf -v progress_line '  %b%s%s%b%s%b %3d%% %s %b%s%b' \
+			"$bar_colour" "$completed_bar" "$head" "$remaining_colour" "$remaining_bar" \
+			"$colour_reset" "$percent" "$count" "$status_colour" "$symbol" "$colour_reset"
+	else
+		printf -v progress_line '  %b%s%s%b%s%b %3d%% %s %b%s%b %s' \
+			"$bar_colour" "$completed_bar" "$head" "$remaining_colour" "$remaining_bar" \
+			"$colour_reset" "$percent" "$count" "$status_colour" "$symbol" "$colour_reset" \
+			"$live_label"
+	fi
+	if [ "$live_output" -eq 0 ]; then
+		printf '%s\n' "$progress_line"
+		return
+	fi
+	if [ "$SETUP_PROGRESS_CURRENT" -eq "$SETUP_PROGRESS_TOTAL" ]; then
+		printf '\r\033[2K%s\n' "$progress_line"
+		SETUP_PROGRESS_VISIBLE=0
+		return
+	fi
+	printf '\r\033[2K%s' "$progress_line"
+	SETUP_PROGRESS_VISIBLE=1
 }
 
 # Evaluate the Homebrew shellenv matching the current architecture.
@@ -206,6 +276,7 @@ run_function() {
 	*e*) had_errexit=1 ;;
 	esac
 
+	setup_progress_clear
 	if command -v gum >/dev/null 2>&1; then
 		gum style --foreground 212 --bold ">>> $func_name"
 	else

--- a/tools/macos_helpers.sh
+++ b/tools/macos_helpers.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# macOS system-tool validation helpers, isolated for focused tests.
+
+clt_receipt_exists() {
+	/usr/sbin/pkgutil --pkg-info=com.apple.pkg.CLTools_Executables &>/dev/null
+}
+
+standalone_command_line_tools_exist() {
+	[ -d /Library/Developer/CommandLineTools ]
+}
+
+available_command_line_tools_label() {
+	/usr/sbin/softwareupdate --list 2>&1 |
+		grep -B 1 -E 'Command Line Tools' |
+		awk -F'*' '/^ *\*/ {print $2}' |
+		sed -e 's/^ *Label: //' -e 's/^ *//' |
+		sort -V |
+		tail -n 1
+}
+
+command_line_tools_label_if_required() {
+	if [ "$1" != true ]; then
+		return 1
+	fi
+	available_command_line_tools_label
+}
+
+move_stale_command_line_tools() {
+	local clt_dir="/Library/Developer/CommandLineTools"
+	local stale_clt_backup
+
+	stale_clt_backup="${clt_dir}.stale-$(date '+%Y%m%d%H%M%S').$$"
+	log "Moving stale standalone Command Line Tools to $stale_clt_backup"
+	/usr/bin/sudo -n /bin/mv "$clt_dir" "$stale_clt_backup"
+}
+
+command_line_tools_are_current() {
+	local brew_doctor_output
+
+	clt_receipt_exists || return 1
+	if ! command -v brew >/dev/null 2>&1; then
+		return 0
+	fi
+	brew_doctor_output="$(brew doctor 2>&1 || true)"
+	if printf '%s\n' "$brew_doctor_output" |
+		grep -qiE 'Command Line Tools are too outdated|outdated Command Line Tools|Xcode alone is not sufficient'; then
+		return 1
+	fi
+}
+
+brew_requires_standalone_command_line_tools() {
+	local brew_doctor_output
+
+	if ! command -v brew >/dev/null 2>&1; then
+		return 1
+	fi
+	brew_doctor_output="$(brew doctor 2>&1 || true)"
+	printf '%s\n' "$brew_doctor_output" | grep -qi 'Xcode alone is not sufficient'
+}
+
+command_line_tools_update_required() {
+	local full_xcode_available="$1"
+
+	if command_line_tools_are_current; then
+		return 1
+	fi
+	if [ "$full_xcode_available" = true ] && ! standalone_command_line_tools_exist &&
+		! brew_requires_standalone_command_line_tools; then
+		return 1
+	fi
+}
+
+use_full_xcode_for_invalid_command_line_tools() {
+	local full_xcode_available="$1"
+
+	if command_line_tools_are_current; then
+		return 0
+	fi
+	if [ "$full_xcode_available" = false ] || brew_requires_standalone_command_line_tools; then
+		return 1
+	fi
+	if standalone_command_line_tools_exist; then
+		move_stale_command_line_tools || return 1
+	fi
+	log "Standalone Command Line Tools remain invalid; using the active full Xcode toolchain."
+}

--- a/tools/setup_macos.sh
+++ b/tools/setup_macos.sh
@@ -675,6 +675,7 @@ main() {
 	if ! xcode-select -p &>/dev/null; then
 		clt_was_missing=true
 		run_functions "${preflight_steps[@]}"
+		setup_progress_clear
 		# Git cannot read the existing identity until this required preflight succeeds.
 		if [ ${#failed_functions[@]} -ne 0 ]; then
 			return 1
@@ -687,6 +688,7 @@ main() {
 		before_brew_steps=("${preflight_steps[@]}" "${before_brew_steps[@]}")
 	fi
 	run_functions "${before_brew_steps[@]}"
+	setup_progress_clear
 	# run_function isolates each step so errors are reliable. Refresh the
 	# environment changes made by install_homebrew in the parent shell.
 	brew_shellenv

--- a/tools/setup_macos.sh
+++ b/tools/setup_macos.sh
@@ -16,11 +16,12 @@ export NONINTERACTIVE=1
 export HOMEBREW_NO_ASK=1
 export GIT_TERMINAL_PROMPT=0
 export GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=10"
-unset INTERACTIVE HOMEBREW_ASK
+unset INTERACTIVE HOMEBREW_ASK HOMEBREW_NO_INSTALL_FROM_API
 set -e
 set -o pipefail
 
 source "$PROFILE_DIR/tools/common.sh"
+source "$PROFILE_DIR/tools/macos_helpers.sh"
 trap 'handle_error $LINENO' ERR
 
 # Prompt for sudo once, then keep the timestamp warm for the whole install.
@@ -51,19 +52,15 @@ install_command_line_tools() {
 	if [ -z "$developer_dir" ]; then
 		clt_missing=true
 		clt_update_required=true
-	elif ! /usr/sbin/pkgutil --pkg-info=com.apple.pkg.CLTools_Executables &>/dev/null; then
-		# Prefer a current standalone CLT when softwareupdate offers one. A full
-		# Xcode toolchain is still a valid fallback when it does not.
-		log "Command Line Tools receipt is missing; checking for the current package..."
-		clt_update_required=true
-	elif command -v brew >/dev/null 2>&1; then
-		local brew_doctor_output
-		brew_doctor_output="$(brew doctor 2>&1 || true)"
-		if printf '%s\n' "$brew_doctor_output" |
-			grep -qiE 'newer Command Line Tools release is available|Command Line Tools are too outdated|outdated Command Line Tools'; then
+	elif command_line_tools_update_required "$full_xcode_available"; then
+		if ! clt_receipt_exists; then
+			# Prefer a current standalone CLT when softwareupdate offers one. A full
+			# Xcode toolchain is still a valid fallback when it does not.
+			log "Command Line Tools receipt is missing; checking for the current package..."
+		else
 			log "Command Line Tools are outdated; checking for the current package..."
-			clt_update_required=true
 		fi
+		clt_update_required=true
 	fi
 
 	if [ "$clt_update_required" = true ]; then
@@ -71,34 +68,20 @@ install_command_line_tools() {
 		# This marker makes softwareupdate include the standalone CLT package even
 		# when Xcode or an older CLT is already selected.
 		/usr/bin/sudo -n /usr/bin/touch "$clt_placeholder"
-	fi
-
-	clt_label=$(
-		/usr/sbin/softwareupdate --list 2>&1 |
-			grep -B 1 -E 'Command Line Tools' |
-			awk -F'*' '/^ *\*/ {print $2}' |
-			sed -e 's/^ *Label: //' -e 's/^ *//' |
-			sort -V |
-			tail -n 1
-	) || true
-
-	if [ "$clt_update_required" = true ]; then
+		clt_label="$(command_line_tools_label_if_required "$clt_update_required")" || true
 		/usr/bin/sudo -n /bin/rm -f "$clt_placeholder"
+
+		if [ -n "$clt_label" ]; then
+			log "Installing $clt_label..."
+			if ! /usr/bin/sudo -n /usr/sbin/softwareupdate --install "$clt_label" --agree-to-license; then
+				log "softwareupdate did not install $clt_label; validating the active toolchain."
+			fi
+		fi
 	fi
 
-	if [ -n "$clt_label" ]; then
-		log "Installing $clt_label..."
-		/usr/bin/sudo -n /usr/sbin/softwareupdate --install "$clt_label" --agree-to-license
-	elif [ "$clt_update_required" = true ] && [ "$full_xcode_available" = true ]; then
-		if [ -d /Library/Developer/CommandLineTools ]; then
-			local stale_clt_backup
-			stale_clt_backup="/Library/Developer/CommandLineTools.stale-$(date '+%Y%m%d%H%M%S')"
-			log "Moving stale standalone Command Line Tools to $stale_clt_backup"
-			/usr/bin/sudo -n /bin/mv /Library/Developer/CommandLineTools "$stale_clt_backup"
-		fi
-		log "softwareupdate did not offer standalone Command Line Tools; using the active full Xcode toolchain."
-	elif [ "$clt_update_required" = true ]; then
-		log "A current Command Line Tools package is required but softwareupdate did not offer one."
+	if [ "$clt_update_required" = true ] &&
+		! use_full_xcode_for_invalid_command_line_tools "$full_xcode_available"; then
+		log "A current Command Line Tools package is required but softwareupdate did not install one."
 		return 1
 	fi
 
@@ -201,9 +184,6 @@ install_homebrew() {
 	# Set HOMEBREW_NO_AUTO_UPDATE to prevent brew from running git updates
 	# during individual installs (we handle updates explicitly)
 	export HOMEBREW_NO_AUTO_UPDATE=1
-
-	# Ensure Homebrew's git uses the credential helper
-	export HOMEBREW_NO_INSTALL_FROM_API=0
 }
 
 cask_app_artifact_paths() {
@@ -292,9 +272,11 @@ install_packages() {
 	done
 
 	# Remove old/unwanted packages
-	local unwanted=("python@3.8" "python@3.9" "pkg-config" "speedtest-cli")
+	local unwanted=("python@3.8" "python@3.9" "pkgconf" "speedtest-cli")
+	local installed_formulae
+	installed_formulae="$(brew list --formula 2>/dev/null || true)"
 	for pkg in "${unwanted[@]}"; do
-		if brew list "$pkg" &>/dev/null; then
+		if printf '%s\n' "$installed_formulae" | grep -Fxq "$pkg"; then
 			log "Removing unwanted package: $pkg"
 			brew uninstall --ignore-dependencies "$pkg" 2>/dev/null || true
 		fi
@@ -693,7 +675,6 @@ main() {
 	# environment changes made by install_homebrew in the parent shell.
 	brew_shellenv
 	export HOMEBREW_NO_AUTO_UPDATE=1
-	export HOMEBREW_NO_INSTALL_FROM_API=0
 	run_functions "${after_brew_steps[@]}"
 
 	# Report failures if any

--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -1035,6 +1035,7 @@ main() {
 
 	# copy_dotfiles must run first — it sources .bash_aliases which defines apt_upgrader
 	run_functions "${bootstrap_steps[@]}"
+	setup_progress_clear
 	# run_function isolates setup steps so failures cannot be masked. Source the
 	# copied aliases in the parent as well because later steps use apt_upgrader.
 	if [ -f "$HOME/.bash_aliases" ]; then


### PR DESCRIPTION
Render one in-place setup progress bar and restore reliable Homebrew package installation on macOS.

## Summary by Sourcery

Stabilize setup progress display and macOS dependency installation.

Bug Fixes:
- Stabilize macOS setup package installation by restoring Homebrew API-based resolution and validating Command Line Tools updates with appropriate Xcode fallback behavior.

Enhancements:
- Render interactive setup progress as a single in-place bar that preserves aggregate failures, clears before step output, and adapts to terminal width while retaining newline output for non-interactive runs.

Documentation:
- Update setup guidance and contributor checks for interactive progress behavior, Homebrew environment handling, and macOS helper validation.

Tests:
- Add regression coverage for live progress rendering, failure aggregation, narrow terminals, and macOS Homebrew and Command Line Tools states.