### PR TITLE
fix(macos): restore Homebrew package setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,10 @@ setup step.
 ## Linting Shell Scripts
 
 ```bash
-shellcheck tools/setup_macos.sh tools/setup_ubuntu.sh tools/common.sh setup_entry.sh
-shfmt -d tools/setup_macos.sh tools/setup_ubuntu.sh tools/common.sh setup_entry.sh
+shellcheck tools/setup_macos.sh tools/setup_ubuntu.sh tools/common.sh tools/macos_helpers.sh setup_entry.sh
+shfmt -d tools/setup_macos.sh tools/setup_ubuntu.sh tools/common.sh tools/macos_helpers.sh setup_entry.sh
 bash tests/setup_logging/run.sh
+bash tests/setup_macos/run.sh
 bash tests/setup_progress/run.sh
 ```
 

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -48,6 +48,11 @@ For macOS, add the package to `tools/Brewfile` (formula or cask) so
 extra wiring (start a service, link a CLI, copy config). Don't shell out to a
 manual installer on macOS when a maintained formula/cask exists.
 
+Homebrew's negative boolean environment flags are enabled by their presence,
+including when set to `0`. Unset `HOMEBREW_NO_INSTALL_FROM_API` to use the JSON
+API. After untapping `homebrew/core`, inspect installed formulae with one
+unnamed `brew list --formula`; a named lookup can clone the tap again.
+
 ## General conventions (enforced)
 
 - Tabs for indentation in shell scripts (not spaces).

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -29,6 +29,28 @@
       directory-shaped latest pointers, inherited shell options, and the fresh
       macOS preflight count. The final review reported no remaining findings.
 
+# Fix monitored macOS package failures
+
+- [x] Reproduce the cask resolution failure from Homebrew's negative API flag.
+- [x] Enable API installs by leaving `HOMEBREW_NO_INSTALL_FROM_API` unset.
+- [x] Validate CLT state after `softwareupdate` and fall back to active Xcode
+      when a stale standalone installation remains.
+- [x] Avoid cloning `homebrew-core` while checking unwanted installed formulae.
+- [x] Add focused regressions and run shell checks.
+- [x] Obtain an independent review and prepare a separate pull request.
+
+## Review
+
+- [x] Confirmed live that setting the negative API flag to `0` breaks cask
+      lookup while leaving it unset resolves the same casks.
+- [x] Added post-update CLT validation with a recoverable stale-directory
+      backup only when full Xcode is valid and sufficient.
+- [x] Covered current, missing, outdated, advisory, stale, Xcode-only, and
+      standalone-required toolchain states with isolated stubs.
+- [x] Verified all focused regressions, syntax, formatting, lint, and the live
+      read-only cask and current-machine predicate checks.
+- [x] Independent final review reported no remaining findings.
+
 # Repair missing Homebrew cask applications
 
 - [x] Reproduce the stale-receipt state where Homebrew reports a cask installed

--- a/tests/setup_macos/run.sh
+++ b/tests/setup_macos/run.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+
+# shellcheck disable=SC1091
+source "$repo_root/tools/common.sh"
+# shellcheck disable=SC1091
+source "$repo_root/tools/macos_helpers.sh"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+mkdir -p "$tmp/bin"
+
+# shellcheck disable=SC2016
+printf '%s\n' \
+	'#!/bin/bash' \
+	'if [ "${PROFILE_TEST_BREW_OUTDATED:-0}" = 1 ]; then' \
+	'  printf "Warning: Your Command Line Tools are too outdated.\\n"' \
+	'elif [ "${PROFILE_TEST_BREW_OUTDATED:-0}" = 2 ]; then' \
+	'  printf "Warning: A newer Command Line Tools release is available.\\n"' \
+	'elif [ "${PROFILE_TEST_BREW_OUTDATED:-0}" = 3 ]; then' \
+	'  printf "Error: Xcode alone is not sufficient on this macOS release.\\n"' \
+	'fi' >"$tmp/bin/brew"
+chmod +x "$tmp/bin/brew"
+
+export PATH="$tmp/bin:/usr/bin:/bin"
+
+clt_receipt_exists() {
+	return "${PROFILE_TEST_PKGUTIL_STATUS:-0}"
+}
+
+standalone_command_line_tools_exist() {
+	return "${PROFILE_TEST_CLT_DIR_STATUS:-1}"
+}
+
+move_stale_command_line_tools() {
+	printf 'called\n' >>"$tmp/sudo.log"
+}
+
+available_command_line_tools_label() {
+	printf 'called\n' >>"$tmp/softwareupdate.log"
+	printf '%s\n' 'Command Line Tools fixture'
+}
+
+if grep -q 'HOMEBREW_NO_INSTALL_FROM_API=' "$repo_root/tools/setup_macos.sh" ||
+	! grep -Eq '^unset .*HOMEBREW_NO_INSTALL_FROM_API' "$repo_root/tools/setup_macos.sh"; then
+	printf '%s\n' 'FAIL: Homebrew API opt-out is not unconditionally unset'
+	exit 1
+fi
+if grep -REq 'PROFILE_SETUP_(CLT|PKGUTIL|SUDO)' \
+	"$repo_root/tools/setup_macos.sh" "$repo_root/tools/macos_helpers.sh"; then
+	printf '%s\n' 'FAIL: privileged CLT targets are environment-selectable'
+	exit 1
+fi
+# shellcheck disable=SC2016
+if grep -Fq 'brew list "$pkg"' "$repo_root/tools/setup_macos.sh" ||
+	! grep -Fq 'brew list --formula' "$repo_root/tools/setup_macos.sh"; then
+	printf '%s\n' 'FAIL: unwanted formula checks can re-clone homebrew/core'
+	exit 1
+fi
+
+export PROFILE_TEST_PKGUTIL_STATUS=0
+export PROFILE_TEST_BREW_OUTDATED=0
+if ! command_line_tools_are_current; then
+	printf '%s\n' 'FAIL: current Command Line Tools were rejected'
+	exit 1
+fi
+
+export PROFILE_TEST_PKGUTIL_STATUS=1
+if command_line_tools_are_current; then
+	printf '%s\n' 'FAIL: missing Command Line Tools receipt was accepted'
+	exit 1
+fi
+
+export PROFILE_TEST_PKGUTIL_STATUS=0
+export PROFILE_TEST_BREW_OUTDATED=1
+if command_line_tools_are_current; then
+	printf '%s\n' 'FAIL: outdated Command Line Tools were accepted'
+	exit 1
+fi
+
+export PROFILE_TEST_BREW_OUTDATED=2
+if ! command_line_tools_are_current; then
+	printf '%s\n' 'FAIL: advisory Command Line Tools update was treated as fatal'
+	exit 1
+fi
+
+if command_line_tools_label_if_required false >/dev/null; then
+	printf '%s\n' 'FAIL: optional CLT update unexpectedly returned a label'
+	exit 1
+fi
+if [ -e "$tmp/softwareupdate.log" ]; then
+	printf '%s\n' 'FAIL: optional CLT state invoked softwareupdate listing'
+	exit 1
+fi
+if [ "$(command_line_tools_label_if_required true)" != 'Command Line Tools fixture' ] ||
+	[ "$(wc -l <"$tmp/softwareupdate.log")" -ne 1 ]; then
+	printf '%s\n' 'FAIL: required CLT state did not list updates exactly once'
+	exit 1
+fi
+
+export PROFILE_TEST_BREW_OUTDATED=0
+export PROFILE_TEST_PKGUTIL_STATUS=1
+export PROFILE_TEST_CLT_DIR_STATUS=0
+if ! command_line_tools_update_required true; then
+	printf '%s\n' 'FAIL: stale standalone tools did not request an update'
+	exit 1
+fi
+if ! use_full_xcode_for_invalid_command_line_tools true; then
+	printf '%s\n' 'FAIL: full Xcode did not replace stale standalone tools'
+	exit 1
+fi
+if [ "$(wc -l <"$tmp/sudo.log")" -ne 1 ]; then
+	printf '%s\n' 'FAIL: stale standalone tools were not moved once'
+	exit 1
+fi
+
+if ! command_line_tools_update_required false; then
+	printf '%s\n' 'FAIL: invalid tools without Xcode did not request an update'
+	exit 1
+fi
+if use_full_xcode_for_invalid_command_line_tools false; then
+	printf '%s\n' 'FAIL: invalid standalone tools passed without full Xcode'
+	exit 1
+fi
+if [ "$(wc -l <"$tmp/sudo.log")" -ne 1 ]; then
+	printf '%s\n' 'FAIL: invalid tools were moved without a full Xcode fallback'
+	exit 1
+fi
+
+export PROFILE_TEST_PKGUTIL_STATUS=0
+before_sudo_calls="$(wc -l <"$tmp/sudo.log")"
+if ! use_full_xcode_for_invalid_command_line_tools true; then
+	printf '%s\n' 'FAIL: current standalone tools were rejected'
+	exit 1
+fi
+if [ "$(wc -l <"$tmp/sudo.log")" -ne "$before_sudo_calls" ]; then
+	printf '%s\n' 'FAIL: current standalone tools were modified'
+	exit 1
+fi
+
+export PROFILE_TEST_PKGUTIL_STATUS=1
+export PROFILE_TEST_CLT_DIR_STATUS=1
+before_sudo_calls="$(wc -l <"$tmp/sudo.log")"
+if command_line_tools_update_required true; then
+	printf '%s\n' 'FAIL: Xcode-only state requested another standalone update'
+	exit 1
+fi
+if ! use_full_xcode_for_invalid_command_line_tools true; then
+	printf '%s\n' 'FAIL: full Xcode without standalone tools was rejected'
+	exit 1
+fi
+if [ "$(wc -l <"$tmp/sudo.log")" -ne "$before_sudo_calls" ]; then
+	printf '%s\n' 'FAIL: idempotent full Xcode fallback invoked sudo'
+	exit 1
+fi
+
+export PROFILE_TEST_BREW_OUTDATED=3
+if ! command_line_tools_update_required true; then
+	printf '%s\n' 'FAIL: a mandatory standalone CLT state skipped its update'
+	exit 1
+fi
+if use_full_xcode_for_invalid_command_line_tools true; then
+	printf '%s\n' 'FAIL: full Xcode was accepted when Homebrew requires standalone CLT'
+	exit 1
+fi
+if [ "$(wc -l <"$tmp/sudo.log")" -ne "$before_sudo_calls" ]; then
+	printf '%s\n' 'FAIL: mandatory standalone CLT state moved files before failing'
+	exit 1
+fi
+
+printf '%s\n' 'PASS: Homebrew API and Command Line Tools state are validated'

--- a/tools/macos_helpers.sh
+++ b/tools/macos_helpers.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# macOS system-tool validation helpers, isolated for focused tests.
+
+clt_receipt_exists() {
+	/usr/sbin/pkgutil --pkg-info=com.apple.pkg.CLTools_Executables &>/dev/null
+}
+
+standalone_command_line_tools_exist() {
+	[ -d /Library/Developer/CommandLineTools ]
+}
+
+available_command_line_tools_label() {
+	/usr/sbin/softwareupdate --list 2>&1 |
+		grep -B 1 -E 'Command Line Tools' |
+		awk -F'*' '/^ *\*/ {print $2}' |
+		sed -e 's/^ *Label: //' -e 's/^ *//' |
+		sort -V |
+		tail -n 1
+}
+
+command_line_tools_label_if_required() {
+	if [ "$1" != true ]; then
+		return 1
+	fi
+	available_command_line_tools_label
+}
+
+move_stale_command_line_tools() {
+	local clt_dir="/Library/Developer/CommandLineTools"
+	local stale_clt_backup
+
+	stale_clt_backup="${clt_dir}.stale-$(date '+%Y%m%d%H%M%S').$$"
+	log "Moving stale standalone Command Line Tools to $stale_clt_backup"
+	/usr/bin/sudo -n /bin/mv "$clt_dir" "$stale_clt_backup"
+}
+
+command_line_tools_are_current() {
+	local brew_doctor_output
+
+	clt_receipt_exists || return 1
+	if ! command -v brew >/dev/null 2>&1; then
+		return 0
+	fi
+	brew_doctor_output="$(brew doctor 2>&1 || true)"
+	if printf '%s\n' "$brew_doctor_output" |
+		grep -qiE 'Command Line Tools are too outdated|outdated Command Line Tools|Xcode alone is not sufficient'; then
+		return 1
+	fi
+}
+
+brew_requires_standalone_command_line_tools() {
+	local brew_doctor_output
+
+	if ! command -v brew >/dev/null 2>&1; then
+		return 1
+	fi
+	brew_doctor_output="$(brew doctor 2>&1 || true)"
+	printf '%s\n' "$brew_doctor_output" | grep -qi 'Xcode alone is not sufficient'
+}
+
+command_line_tools_update_required() {
+	local full_xcode_available="$1"
+
+	if command_line_tools_are_current; then
+		return 1
+	fi
+	if [ "$full_xcode_available" = true ] && ! standalone_command_line_tools_exist &&
+		! brew_requires_standalone_command_line_tools; then
+		return 1
+	fi
+}
+
+use_full_xcode_for_invalid_command_line_tools() {
+	local full_xcode_available="$1"
+
+	if command_line_tools_are_current; then
+		return 0
+	fi
+	if [ "$full_xcode_available" = false ] || brew_requires_standalone_command_line_tools; then
+		return 1
+	fi
+	if standalone_command_line_tools_exist; then
+		move_stale_command_line_tools || return 1
+	fi
+	log "Standalone Command Line Tools remain invalid; using the active full Xcode toolchain."
+}

--- a/tools/setup_macos.sh
+++ b/tools/setup_macos.sh
@@ -16,11 +16,12 @@ export NONINTERACTIVE=1
 export HOMEBREW_NO_ASK=1
 export GIT_TERMINAL_PROMPT=0
 export GIT_SSH_COMMAND="ssh -o BatchMode=yes -o ConnectTimeout=10"
-unset INTERACTIVE HOMEBREW_ASK
+unset INTERACTIVE HOMEBREW_ASK HOMEBREW_NO_INSTALL_FROM_API
 set -e
 set -o pipefail
 
 source "$PROFILE_DIR/tools/common.sh"
+source "$PROFILE_DIR/tools/macos_helpers.sh"
 trap 'handle_error $LINENO' ERR
 
 # Prompt for sudo once, then keep the timestamp warm for the whole install.
@@ -51,19 +52,15 @@ install_command_line_tools() {
 	if [ -z "$developer_dir" ]; then
 		clt_missing=true
 		clt_update_required=true
-	elif ! /usr/sbin/pkgutil --pkg-info=com.apple.pkg.CLTools_Executables &>/dev/null; then
-		# Prefer a current standalone CLT when softwareupdate offers one. A full
-		# Xcode toolchain is still a valid fallback when it does not.
-		log "Command Line Tools receipt is missing; checking for the current package..."
-		clt_update_required=true
-	elif command -v brew >/dev/null 2>&1; then
-		local brew_doctor_output
-		brew_doctor_output="$(brew doctor 2>&1 || true)"
-		if printf '%s\n' "$brew_doctor_output" |
-			grep -qiE 'newer Command Line Tools release is available|Command Line Tools are too outdated|outdated Command Line Tools'; then
+	elif command_line_tools_update_required "$full_xcode_available"; then
+		if ! clt_receipt_exists; then
+			# Prefer a current standalone CLT when softwareupdate offers one. A full
+			# Xcode toolchain is still a valid fallback when it does not.
+			log "Command Line Tools receipt is missing; checking for the current package..."
+		else
 			log "Command Line Tools are outdated; checking for the current package..."
-			clt_update_required=true
 		fi
+		clt_update_required=true
 	fi
 
 	if [ "$clt_update_required" = true ]; then
@@ -71,34 +68,20 @@ install_command_line_tools() {
 		# This marker makes softwareupdate include the standalone CLT package even
 		# when Xcode or an older CLT is already selected.
 		/usr/bin/sudo -n /usr/bin/touch "$clt_placeholder"
-	fi
-
-	clt_label=$(
-		/usr/sbin/softwareupdate --list 2>&1 |
-			grep -B 1 -E 'Command Line Tools' |
-			awk -F'*' '/^ *\*/ {print $2}' |
-			sed -e 's/^ *Label: //' -e 's/^ *//' |
-			sort -V |
-			tail -n 1
-	) || true
-
-	if [ "$clt_update_required" = true ]; then
+		clt_label="$(command_line_tools_label_if_required "$clt_update_required")" || true
 		/usr/bin/sudo -n /bin/rm -f "$clt_placeholder"
+
+		if [ -n "$clt_label" ]; then
+			log "Installing $clt_label..."
+			if ! /usr/bin/sudo -n /usr/sbin/softwareupdate --install "$clt_label" --agree-to-license; then
+				log "softwareupdate did not install $clt_label; validating the active toolchain."
+			fi
+		fi
 	fi
 
-	if [ -n "$clt_label" ]; then
-		log "Installing $clt_label..."
-		/usr/bin/sudo -n /usr/sbin/softwareupdate --install "$clt_label" --agree-to-license
-	elif [ "$clt_update_required" = true ] && [ "$full_xcode_available" = true ]; then
-		if [ -d /Library/Developer/CommandLineTools ]; then
-			local stale_clt_backup
-			stale_clt_backup="/Library/Developer/CommandLineTools.stale-$(date '+%Y%m%d%H%M%S')"
-			log "Moving stale standalone Command Line Tools to $stale_clt_backup"
-			/usr/bin/sudo -n /bin/mv /Library/Developer/CommandLineTools "$stale_clt_backup"
-		fi
-		log "softwareupdate did not offer standalone Command Line Tools; using the active full Xcode toolchain."
-	elif [ "$clt_update_required" = true ]; then
-		log "A current Command Line Tools package is required but softwareupdate did not offer one."
+	if [ "$clt_update_required" = true ] &&
+		! use_full_xcode_for_invalid_command_line_tools "$full_xcode_available"; then
+		log "A current Command Line Tools package is required but softwareupdate did not install one."
 		return 1
 	fi
 
@@ -201,9 +184,6 @@ install_homebrew() {
 	# Set HOMEBREW_NO_AUTO_UPDATE to prevent brew from running git updates
 	# during individual installs (we handle updates explicitly)
 	export HOMEBREW_NO_AUTO_UPDATE=1
-
-	# Ensure Homebrew's git uses the credential helper
-	export HOMEBREW_NO_INSTALL_FROM_API=0
 }
 
 cask_app_artifact_paths() {
@@ -292,9 +272,11 @@ install_packages() {
 	done
 
 	# Remove old/unwanted packages
-	local unwanted=("python@3.8" "python@3.9" "pkg-config" "speedtest-cli")
+	local unwanted=("python@3.8" "python@3.9" "pkgconf" "speedtest-cli")
+	local installed_formulae
+	installed_formulae="$(brew list --formula 2>/dev/null || true)"
 	for pkg in "${unwanted[@]}"; do
-		if brew list "$pkg" &>/dev/null; then
+		if printf '%s\n' "$installed_formulae" | grep -Fxq "$pkg"; then
 			log "Removing unwanted package: $pkg"
 			brew uninstall --ignore-dependencies "$pkg" 2>/dev/null || true
 		fi
@@ -691,7 +673,6 @@ main() {
 	# environment changes made by install_homebrew in the parent shell.
 	brew_shellenv
 	export HOMEBREW_NO_AUTO_UPDATE=1
-	export HOMEBREW_NO_INSTALL_FROM_API=0
 	run_functions "${after_brew_steps[@]}"
 
 	# Report failures if any


### PR DESCRIPTION
Restore API-backed cask resolution, validate CLT outcomes, and safely fall back to a sufficient full Xcode toolchain.

## Summary by Sourcery

Restore reliable macOS Homebrew setup by fixing API usage and validating Command Line Tools fallbacks.

Bug Fixes:
- Restore Homebrew API-backed cask and package resolution by leaving the negative API opt-out unset.
- Validate Command Line Tools installation results and safely fall back to a sufficient full Xcode toolchain when appropriate.
- Prevent unwanted formula checks from triggering unnecessary homebrew-core cloning.

Enhancements:
- Centralize macOS Command Line Tools state detection and fallback behavior in reusable helpers.

Documentation:
- Document Homebrew negative boolean flags and the formula-listing approach for avoiding tap cloning.

Tests:
- Add focused macOS setup regressions covering Homebrew API behavior and Command Line Tools state transitions.