### PR TITLE
fix(setup): stabilise live progress and macOS recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,12 @@ Logs and their parent directory are mode `600` and `700` respectively.
 Treat them as private and never commit them.
 
 Each platform's `main` defines its executable function plan. The shared runner
-uses that plan as the progress total and renders a Rich-style bar after each
-setup step.
+uses that plan as the progress total and pins one Rich-style bar below the live
+terminal output. Cursor controls bypass the raw setup log.
+
+Ubuntu retains its sudo timestamp keepalive. Homebrew deliberately invalidates
+macOS sudo timestamps, so later privileged cask operations may request approval
+again; never cache or broker the administrator password in setup code.
 
 ## Linting Shell Scripts
 

--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ $ source setup_entry.sh
 Setup output is stored privately at
 `${XDG_STATE_HOME:-$HOME/.local/state}/profile/setup/latest.log`. Override the
 directory with an absolute `PROFILE_SETUP_LOG_DIR`. The setup shows completed
-steps with a Rich-style progress bar generated from the active platform setup
-functions.
+steps with a Rich-style progress bar pinned below the live terminal output.
+The bar is generated from the active platform setup functions.

--- a/setup_entry.sh
+++ b/setup_entry.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 
 profile_setup_run() {
+	local os_name
+	os_name="$(uname)"
 	export PROFILE_SETUP_NO_LOGIN_SHELL=1
 
-	sudo -v
-
-	if [ "$(uname)" = "Darwin" ]; then
-		# setup_macos installs/updates the Command Line Tools after starting the
-		# sudo keepalive. Running softwareupdate here used to happen before that
-		# keepalive and could cause another password prompt later in the setup.
+	if [ "$os_name" = "Darwin" ]; then
+		# Homebrew revokes cached sudo tickets, so setup_macos requests visible
+		# foreground approval only when a privileged step actually needs it.
 		:
-	elif ! command -v git >/dev/null 2>&1; then
+	else
+		sudo -v
+	fi
+
+	if [ "$os_name" != "Darwin" ] && ! command -v git >/dev/null 2>&1; then
 		echo "git is not installed, installing git."
 		sudo apt-get update
 		sudo apt-get install -y git
@@ -18,16 +21,13 @@ profile_setup_run() {
 
 	# Pull latest version of this repo (non-fatal on first run / auth issues).
 	# Apple's /usr/bin/git is only a launcher until the Command Line Tools exist.
-	if { [ "$(uname)" != "Darwin" ] || xcode-select -p &>/dev/null; } && GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='ssh -o BatchMode=yes -o ConnectTimeout=10' git fetch origin 2>/dev/null; then
+	if { [ "$os_name" != "Darwin" ] || xcode-select -p &>/dev/null; } && GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='ssh -o BatchMode=yes -o ConnectTimeout=10' git fetch origin 2>/dev/null; then
 		git reset --hard origin/main
 		git checkout main
 		GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='ssh -o BatchMode=yes -o ConnectTimeout=10' git pull
 	else
 		echo "Warning: could not fetch from remote, continuing with local copy."
 	fi
-
-	local os_name
-	os_name="$(uname)"
 
 	if [ "$os_name" = "Darwin" ]; then
 		bash tools/setup_macos.sh
@@ -44,12 +44,24 @@ profile_setup_main() {
 	local log_dir
 	local log_file
 	local status_file
+	local progress_file
 	local latest_link
 	local timestamp
 	local setup_status
 	local tee_status
 	local had_pipefail=0
 	local output_tty=0
+	local progress_rows
+	local progress_columns
+	local progress_line
+	local progress_summary
+	local saved_progress_rows
+	local terminal_size
+	local terminal_columns
+	local progress_csr
+	local progress_old_cup
+	local progress_cup
+	local progress_el
 
 	case "${XDG_STATE_HOME:-}" in
 	/*) state_home="$XDG_STATE_HOME" ;;
@@ -107,6 +119,13 @@ profile_setup_main() {
 		unset -f profile_setup_run profile_setup_main
 		return 1
 	fi
+	if ! progress_file="$(umask 077 && mktemp "$log_dir/.setup-progress.XXXXXX")" ||
+		[ -z "$progress_file" ] || ! chmod 600 "$progress_file"; then
+		printf 'Error: could not create setup progress state under: %s\n' "$log_dir" >&2
+		rm -f "$status_file"
+		unset -f profile_setup_run profile_setup_main
+		return 1
+	fi
 	if [ -t 1 ]; then
 		output_tty=1
 	fi
@@ -117,9 +136,13 @@ profile_setup_main() {
 	if (
 		set +e
 		export PROFILE_SETUP_OUTPUT_TTY="$output_tty"
+		if [ "$output_tty" -eq 1 ]; then
+			export PROFILE_SETUP_PROGRESS_FD=9
+			export PROFILE_SETUP_PROGRESS_STATE_FILE="$progress_file"
+		fi
 		profile_setup_run
 		setup_status=$?
-		printf '%s\n' "$setup_status" >"$status_file"
+		printf '%s\n' "$setup_status" >|"$status_file"
 		exit "$setup_status"
 	) 2>&1 | tee -a "$log_file"; then
 		tee_status=0
@@ -149,6 +172,52 @@ profile_setup_main() {
 			setup_status=1
 		fi
 	fi
+	if [ "$output_tty" -eq 1 ] && [ -s "$progress_file" ]; then
+		progress_rows=""
+		progress_columns=""
+		progress_line=""
+		progress_summary=""
+		{
+			IFS= read -r progress_rows || true
+			IFS= read -r progress_columns || true
+			IFS= read -r progress_line || true
+			IFS= read -r progress_summary || true
+		} <"$progress_file"
+		saved_progress_rows="$progress_rows"
+		terminal_size="$(stty size <&9 2>/dev/null || true)"
+		case "$terminal_size" in
+		[0-9]*' '[0-9]*)
+			progress_rows="${terminal_size%% *}"
+			terminal_columns="${terminal_size##* }"
+			;;
+		esac
+		case "$progress_rows" in
+		'' | *[!0-9]* | 0) progress_rows=24 ;;
+		esac
+		case "$saved_progress_rows" in
+		'' | *[!0-9]* | 0) saved_progress_rows="$progress_rows" ;;
+		esac
+		case "$progress_columns" in
+		'' | *[!0-9]* | 0) progress_columns=80 ;;
+		esac
+		case "${terminal_columns:-}" in
+		'' | *[!0-9]* | 0) terminal_columns="$progress_columns" ;;
+		esac
+		if [ "$terminal_columns" -lt "$progress_columns" ]; then
+			progress_line="$(printf '%.*s' "$terminal_columns" "$progress_summary")"
+		fi
+		if progress_csr="$(tput csr 0 "$((progress_rows - 1))" 2>/dev/null)" &&
+			progress_old_cup="$(tput cup "$((saved_progress_rows - 1))" 0 2>/dev/null)" &&
+			progress_cup="$(tput cup "$((progress_rows - 1))" 0 2>/dev/null)" &&
+			progress_el="$(tput el 2>/dev/null)"; then
+			printf '%s%s%s%s%s%s\n' \
+				"$progress_csr" "$progress_old_cup" "$progress_el" \
+				"$progress_cup" "$progress_el" "$progress_line" >&9 || true
+		else
+			printf '\033[r' >&9 || true
+		fi
+	fi
+	rm -f "$progress_file"
 
 	unset -f profile_setup_run profile_setup_main
 	if [ "$setup_status" -ne 0 ]; then
@@ -156,7 +225,7 @@ profile_setup_main() {
 	fi
 
 	# Start the replacement login shell only after tee has closed the log.
-	bash -l
+	bash -l 9>&-
 }
 
-profile_setup_main
+profile_setup_main 9>&1

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -6,9 +6,11 @@ Update this file whenever a correction reveals a rule worth keeping.
 ## Progress presentation
 
 Use one in-place, bright-green Rich-style bar for shared interactive terminal
-setup progress on both platforms. Do not emit a new bar line after every step,
-and do not apply the Nova UI palette unless Alex explicitly asks for it. Keep
-newline-based output for non-interactive runs.
+setup progress on both platforms. The bar must remain visible at the bottom
+while the current function emits output, not disappear until that function
+finishes. Do not emit a new bar line after every step, and do not apply the
+Nova UI palette unless Alex explicitly asks for it. Keep newline-based output
+for non-interactive runs.
 
 ## Where a new install goes
 
@@ -53,6 +55,16 @@ Homebrew's negative boolean environment flags are enabled by their presence,
 including when set to `0`. Unset `HOMEBREW_NO_INSTALL_FROM_API` to use the JSON
 API. After untapping `homebrew/core`, inspect installed formulae with one
 unnamed `brew list --formula`; a named lookup can clone the tap again.
+
+Homebrew invalidates macOS sudo timestamps on every invocation. macOS setup
+cannot safely guarantee a single password prompt with a timestamp keepalive.
+Do not cache or broker the administrator password: Homebrew children could use
+that credential to authorise arbitrary root commands. Use visible foreground
+sudo for explicit recovery and accept Homebrew's own security boundary.
+
+After validating application artefacts, exclude installed casks marked
+`auto_updates` from `brew bundle` upgrades. Their own updater owns freshness,
+and an upstream download outage must not block unrelated Brewfile installs.
 
 ## General conventions (enforced)
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,28 @@
+# Keep live setup progress visible and repair sudo recovery
+
+- [x] Pin one bright-green progress bar to the interactive terminal footer.
+- [x] Keep raw logs free of cursor controls and retain non-interactive progress.
+- [x] Restore the terminal on completion, failure, interruption, and resize.
+- [x] Re-prompt visibly when Homebrew invalidates macOS sudo credentials.
+- [x] Prefer valid full Xcode and isolate installed self-updating casks.
+- [x] Add focused regressions and run the repository shell checks.
+- [x] Obtain an independent review and prepare a follow-up pull request.
+
+## Review
+
+- [x] The monitored macOS run attempted all 21 functions. Command Line Tools
+      recovery failed after Homebrew invalidated sudo, and an upstream WhatsApp
+      HTTP 500 made the cask bundle report failure; later functions completed.
+- [x] macOS and Ubuntu now keep one progress bar pinned below live output while
+      logs remain chronological and free of terminal cursor controls.
+- [x] macOS recovery uses visible foreground sudo without caching a password,
+      prefers a valid full Xcode toolchain, and skips upgrades for installed
+      self-updating casks after validating their application artefacts.
+- [x] Verified focused progress, logging/PTY, macOS recovery, Bash 3.2 syntax,
+      formatting, focused lint, and diff checks.
+- [x] Independent review found no remaining material correctness, security, or
+      user-experience issues.
+
 # Render one interactive setup progress bar
 
 - [x] Replace per-step interactive progress lines with one in-place bar.

--- a/tests/setup_logging/run.sh
+++ b/tests/setup_logging/run.sh
@@ -26,13 +26,37 @@ printf '%s\n' \
 # shellcheck disable=SC2016
 printf '%s\n' \
 	'#!/bin/bash' \
+	'# shellcheck disable=SC1090' \
+	'source "$PROFILE_TEST_COMMON"' \
+	'fixture_step() {' \
+	'  if [ "${PROFILE_SETUP_PROGRESS_FD:-}" = 9 ] && (: >&9) 2>/dev/null; then' \
+	'    printf "FAIL: platform child inherited FD 9\\n" >&2' \
+	'    return 97' \
+	'  fi' \
+	'  printf "platform stdout\\n"' \
+	'  printf "platform stderr\\n" >&2' \
+	'  return "${PROFILE_TEST_CHILD_STATUS:-0}"' \
+	'}' \
+	'failed_functions=()' \
+	'setup_progress_start fixture_step' \
+	'run_function fixture_step' \
+	'if [ "${PROFILE_TEST_RESIZE_TAIL:-0}" = 1 ]; then' \
+	'  stty rows 24 cols 24 <&9' \
+	'  setup_progress_handle_resize' \
+	'fi' \
+	'exit "${PROFILE_TEST_CHILD_STATUS:-0}"' >"$tmp/platform-fixture"
+# shellcheck disable=SC2016
+printf '%s\n' \
+	'#!/bin/bash' \
 	'case "${1:-}" in' \
 	'tools/setup_macos.sh)' \
-	'	printf "platform stdout\\n"' \
-	'	printf "platform stderr\\n" >&2' \
-	'	exit "${PROFILE_TEST_CHILD_STATUS:-0}"' \
+	'	exec /bin/bash "$PROFILE_TEST_PLATFORM_FIXTURE"' \
 	'	;;' \
 	'-l)' \
+	'	if (: >&9) 2>/dev/null; then' \
+	'		printf "FAIL: login shell inherited FD 9\\n" >&2' \
+	'		exit 97' \
+	'	fi' \
 	'	printf "LOGIN_SHELL_AFTER_LOG\\n"' \
 	'	exit 0' \
 	'	;;' \
@@ -40,6 +64,9 @@ printf '%s\n' \
 	'printf "FAIL: unexpected bash arguments: %s\\n" "$*" >&2' \
 	'exit 98' >"$tmp/bin/bash"
 chmod +x "$tmp/bin/"*
+chmod +x "$tmp/platform-fixture"
+export PROFILE_TEST_COMMON="$repo_root/tools/common.sh"
+export PROFILE_TEST_PLATFORM_FIXTURE="$tmp/platform-fixture"
 
 assert_contains() {
 	local value="$1"
@@ -81,8 +108,11 @@ source_output="$(
 			before_umask="$(umask)"
 			trap ":" USR1
 			before_trap="$(trap -p USR1)"
+			exec 9>"$2"
 			source "$1"
 			source_status=$?
+			printf "CALLER_FD9_OK\n" >&9
+			exec 9>&-
 			if [ "$PWD" = "$before_pwd" ] &&
 				[ "$-" = "$before_options" ] &&
 				[ "$(set -o | grep "^pipefail")" = "$before_pipefail" ] &&
@@ -94,7 +124,7 @@ source_output="$(
 			fi
 			printf "SOURCE_STATUS=%s\\n" "$source_status"
 			printf "CALLER_AFTER\\n"
-		' _ "$entry" 2>&1
+		' _ "$entry" "$tmp/caller-fd9" 2>&1
 )"
 
 assert_contains "$source_output" "platform stdout"
@@ -104,6 +134,10 @@ assert_contains "$source_output" "CALLER_STATE_OK"
 assert_contains "$source_output" "SOURCE_STATUS=0"
 assert_contains "$source_output" "CALLER_AFTER"
 assert_not_contains "$source_output" "FAIL:"
+if [ "$(<"$tmp/caller-fd9")" != CALLER_FD9_OK ]; then
+	printf '%s\n' 'FAIL: sourced setup did not restore the caller FD 9'
+	exit 1
+fi
 
 if [ "$(file_mode "$log_dir")" != 700 ]; then
 	printf 'FAIL: log directory mode is %s\n' "$(file_mode "$log_dir")"
@@ -123,6 +157,7 @@ assert_contains "$first_contents" "platform stdout"
 assert_contains "$first_contents" "platform stderr"
 assert_not_contains "$first_contents" "LOGIN_SHELL_AFTER_LOG"
 assert_not_contains "$first_contents" "CALLER_AFTER"
+assert_not_contains "$first_contents" $'\033[1;23r'
 
 if [ -x /bin/zsh ]; then
 	zsh_log_dir="$tmp/zsh logs"
@@ -181,6 +216,23 @@ fi
 assert_contains "$errexit_output" "platform stderr"
 assert_not_contains "$errexit_output" "LOGIN_SHELL_AFTER_LOG"
 assert_not_contains "$errexit_output" "could not finish writing setup log"
+
+noclobber_log_dir="$tmp/noclobber logs"
+noclobber_output="$(
+	PATH="$tmp/bin:$PATH" \
+		PROFILE_SETUP_LOG_DIR="$noclobber_log_dir" \
+		PROFILE_TEST_CHILD_STATUS=0 \
+		/bin/bash -C -c '
+			source "$1"
+			printf "SOURCE_STATUS=%s\n" "$?"
+			case $- in
+			*C*) printf "NOCLOBBER_RESTORED\n" ;;
+			esac
+		' _ "$entry" 2>&1
+)"
+assert_contains "$noclobber_output" "SOURCE_STATUS=0"
+assert_contains "$noclobber_output" "NOCLOBBER_RESTORED"
+assert_not_contains "$noclobber_output" "FAIL:"
 
 execute_log_dir="$tmp/executed logs"
 set +e
@@ -246,6 +298,56 @@ if [ ! -L "$linked_log_dir/latest.log" ] ||
 	find "$linked_log_dir/archive" -mindepth 1 -print -quit | grep -q .; then
 	printf '%s\n' 'FAIL: symlinked latest.log directory was modified'
 	exit 1
+fi
+
+if [ "$(/usr/bin/uname)" = Darwin ]; then
+	pty_log_dir="$tmp/pty logs"
+	pty_transcript="$tmp/pty-transcript"
+	set +e
+	/usr/bin/script -q "$pty_transcript" /usr/bin/env \
+		"PATH=$tmp/bin:$PATH" \
+		"PROFILE_SETUP_LOG_DIR=$pty_log_dir" \
+		PROFILE_TEST_CHILD_STATUS=0 \
+		PROFILE_TEST_RESIZE_TAIL=1 \
+		PROFILE_TEST_COMMON="$PROFILE_TEST_COMMON" \
+		PROFILE_TEST_PLATFORM_FIXTURE="$PROFILE_TEST_PLATFORM_FIXTURE" \
+		TERM=xterm-256color LINES=24 COLUMNS=80 NO_COLOR=1 \
+		/bin/bash "$entry" >"$tmp/pty-stdout" 2>&1
+	pty_status=$?
+	set -e
+	if [ "$pty_status" -ne 0 ]; then
+		printf 'FAIL: PTY entry point returned %s\n%s\n' "$pty_status" "$(<"$tmp/pty-stdout")"
+		exit 1
+	fi
+	pty_contents="$(<"$pty_transcript")"
+	assert_contains "$pty_contents" $'\033[1;23r'
+	assert_contains "$pty_contents" "platform stdout"
+	assert_contains "$pty_contents" "100% 1/1 ✓"
+	assert_contains "$pty_contents" "LOGIN_SHELL_AFTER_LOG"
+	assert_not_contains "$pty_contents" "FAIL:"
+	log_saved_offset="$(LC_ALL=C grep -abo 'Setup log saved to:' "$pty_transcript" |
+		awk -F: '{ offset = $1 } END { print offset }')"
+	final_bar_offset="$(LC_ALL=C grep -abo '100% 1/1' "$pty_transcript" |
+		awk -F: '{ offset = $1 } END { print offset }')"
+	if [ -z "$log_saved_offset" ] || [ -z "$final_bar_offset" ] ||
+		[ "$final_bar_offset" -le "$log_saved_offset" ]; then
+		printf '%s\n' 'FAIL: final footer was not rendered after the log-save message'
+		exit 1
+	fi
+	pty_log="$pty_log_dir/$(readlink "$pty_log_dir/latest.log")"
+	pty_log_contents="$(<"$pty_log")"
+	assert_contains "$pty_log_contents" "platform stdout"
+	assert_not_contains "$pty_log_contents" $'\033[1;23r'
+	assert_not_contains "$pty_log_contents" "100% 1/1 ✓"
+	if LC_ALL=C grep -Eq $'\033\\[[0-9;]*r' "$pty_log"; then
+		printf '%s\n' 'FAIL: raw setup log contains terminal scroll-region controls'
+		exit 1
+	fi
+	if find "$pty_log_dir" \( -name '.setup-status.*' -o -name '.setup-progress.*' \) \
+		-print -quit | grep -q .; then
+		printf '%s\n' 'FAIL: PTY setup left private state files behind'
+		exit 1
+	fi
 fi
 
 printf '%s\n' 'PASS: setup logs are private, complete, discoverable, and bounded'

--- a/tests/setup_macos/run.sh
+++ b/tests/setup_macos/run.sh
@@ -16,7 +16,13 @@ mkdir -p "$tmp/bin"
 # shellcheck disable=SC2016
 printf '%s\n' \
 	'#!/bin/bash' \
-	'if [ "${PROFILE_TEST_BREW_OUTDATED:-0}" = 1 ]; then' \
+	'if [ "$*" = "info --cask self-updating" ]; then' \
+	'  printf "==> self-updating: 1.0 (auto_updates)\\n"' \
+	'elif [ "$*" = "info --cask incomplete-self-updating" ]; then' \
+	'  printf "==> incomplete-self-updating: 1.0 (auto_updates)\\n"' \
+	'elif [ "$*" = "info --cask managed-update" ]; then' \
+	'  printf "==> managed-update: 1.0\\n"' \
+	'elif [ "${PROFILE_TEST_BREW_OUTDATED:-0}" = 1 ]; then' \
 	'  printf "Warning: Your Command Line Tools are too outdated.\\n"' \
 	'elif [ "${PROFILE_TEST_BREW_OUTDATED:-0}" = 2 ]; then' \
 	'  printf "Warning: A newer Command Line Tools release is available.\\n"' \
@@ -52,6 +58,35 @@ fi
 if grep -REq 'PROFILE_SETUP_(CLT|PKGUTIL|SUDO)' \
 	"$repo_root/tools/setup_macos.sh" "$repo_root/tools/macos_helpers.sh"; then
 	printf '%s\n' 'FAIL: privileged CLT targets are environment-selectable'
+	exit 1
+fi
+if grep -Eq '/usr/bin/sudo +-n' "$repo_root/tools/setup_macos.sh" \
+	"$repo_root/tools/macos_helpers.sh"; then
+	printf '%s\n' 'FAIL: macOS CLT recovery still assumes a valid sudo timestamp'
+	exit 1
+fi
+if ! cask_auto_updates self-updating || cask_auto_updates managed-update; then
+	printf '%s\n' 'FAIL: self-updating cask detection is incorrect'
+	exit 1
+fi
+cask_has_missing_app_artifact() {
+	[ "$1" = incomplete-self-updating ]
+}
+selected_casks="$(casks_managed_by_own_updater \
+	self-updating managed-update incomplete-self-updating)"
+# shellcheck disable=SC2016 # The production variable reference is intentional.
+if [ "$selected_casks" != self-updating ] ||
+	! grep -Fq 'HOMEBREW_BUNDLE_CASK_SKIP="$installed_auto_update_casks"' \
+		"$repo_root/tools/setup_macos.sh"; then
+	printf '%s\n' 'FAIL: cask bundle skip does not contain exactly valid self-updating apps'
+	exit 1
+fi
+fallback_line="$(grep -n 'use_full_xcode_for_invalid_command_line_tools' \
+	"$repo_root/tools/setup_macos.sh" | head -n 1 | cut -d: -f1)"
+update_line="$(grep -n 'Searching for Xcode Command Line Tools' \
+	"$repo_root/tools/setup_macos.sh" | cut -d: -f1)"
+if [ -z "$fallback_line" ] || [ -z "$update_line" ] || [ "$fallback_line" -ge "$update_line" ]; then
+	printf '%s\n' 'FAIL: valid full Xcode is not preferred before standalone CLT updates'
 	exit 1
 fi
 # shellcheck disable=SC2016
@@ -168,6 +203,18 @@ if use_full_xcode_for_invalid_command_line_tools true; then
 fi
 if [ "$(wc -l <"$tmp/sudo.log")" -ne "$before_sudo_calls" ]; then
 	printf '%s\n' 'FAIL: mandatory standalone CLT state moved files before failing'
+	exit 1
+fi
+
+sudo_command() {
+	printf '%s\n' "$*" >>"$tmp/foreground-sudo.log"
+	[ "$*" != '-n -v' ]
+}
+run_sudo_output="$(run_sudo /bin/mv source target)"
+if ! grep -Fxq -- '-n -v' "$tmp/foreground-sudo.log" ||
+	! grep -Fxq -- '/bin/mv source target' "$tmp/foreground-sudo.log" ||
+	[[ "$run_sudo_output" != *'Administrator approval is required to continue.'* ]]; then
+	printf '%s\n' 'FAIL: invalidated sudo credentials did not fall back visibly'
 	exit 1
 fi
 

--- a/tests/setup_progress/run.sh
+++ b/tests/setup_progress/run.sh
@@ -11,10 +11,18 @@ tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
 first_step() {
-	:
+	if [ "${PROFILE_SETUP_PROGRESS_FD:-}" = 9 ]; then
+		if (: >&9) 2>/dev/null; then
+			printf '%s\n' 'CHILD_FD9_LEAKED'
+			return 11
+		fi
+		printf '%s\n' 'CHILD_FD9_CLOSED'
+	fi
+	printf '%s\n' 'FIRST_OUTPUT'
 }
 
 second_step() {
+	printf '%s\n' 'SECOND_OUTPUT'
 	return 7
 }
 
@@ -22,48 +30,66 @@ fail_first() {
 	return 9
 }
 
-export NO_COLOR=1
+assert_contains() {
+	local value="$1"
+	local expected="$2"
+
+	if [[ "$value" == *"$expected"* ]]; then
+		return
+	fi
+	printf 'FAIL: expected output to contain %q\n%s\n' "$expected" "$value"
+	exit 1
+}
+
+assert_not_contains() {
+	local value="$1"
+	local unexpected="$2"
+
+	if [[ "$value" != *"$unexpected"* ]]; then
+		return
+	fi
+	printf 'FAIL: expected output not to contain %q\n%s\n' "$unexpected" "$value"
+	exit 1
+}
+
 export PATH="/usr/bin:/bin"
 export PROFILE_SETUP_OUTPUT_TTY=1
+export PROFILE_SETUP_PROGRESS_FD=9
 export LC_ALL="C.UTF-8"
 export TERM=xterm-256color
+export LINES=24
 export COLUMNS=80
+export NO_COLOR=1
+
 failed_functions=()
 first_phase=(first_step)
 second_phase=(second_step)
 setup_progress_start "${first_phase[@]}" "${second_phase[@]}"
-output_file="$tmp/progress-output"
 {
 	run_functions "${first_phase[@]}"
-	setup_progress_clear
 	printf '%s\n' 'PARENT_HOOK'
 	run_functions "${second_phase[@]}"
-} >"$output_file" 2>&1
-output="$(<"$output_file")"
+} >"$tmp/setup-output" 2>&1 9>"$tmp/ui-output"
+setup_output="$(<"$tmp/setup-output")"
+ui_output="$(<"$tmp/ui-output")"
 
-if [[ "$output" != *"50% 1/2 ✓ first_step"* ]]; then
-	printf 'FAIL: first progress update is missing\n%s\n' "$output"
-	exit 1
-fi
-if [[ "$output" != *"100% 2/2 ✗ second_step"* ]]; then
-	printf 'FAIL: final progress update is missing\n%s\n' "$output"
-	exit 1
-fi
-final_progress="$(printf '%s\n' "$output" | grep '100% 2/2')"
-if [[ "$final_progress" == *"╺"* ]]; then
-	printf 'FAIL: completed progress bar still has a continuation marker\n%s\n' "$final_progress"
-	exit 1
-fi
-if [[ "$output" != *"━"* ]]; then
-	printf 'FAIL: Rich-style progress bar is missing\n%s\n' "$output"
-	exit 1
-fi
-if [[ "$output" != *"50% 1/2 ✓ first_step"$'\r\033[2K'"PARENT_HOOK"* ]]; then
-	printf 'FAIL: incomplete progress did not redraw in place\n%s\n' "$output"
-	exit 1
-fi
-if [[ "$output" != *"first_step"*"PARENT_HOOK"*"second_step"* ]]; then
-	printf 'FAIL: phased execution order changed\n%s\n' "$output"
+assert_contains "$setup_output" "FIRST_OUTPUT"
+assert_contains "$setup_output" "CHILD_FD9_CLOSED"
+assert_not_contains "$setup_output" "CHILD_FD9_LEAKED"
+assert_contains "$setup_output" "PARENT_HOOK"
+assert_contains "$setup_output" "SECOND_OUTPUT"
+assert_not_contains "$setup_output" "0% 0/2"
+assert_not_contains "$setup_output" "━"
+assert_not_contains "$setup_output" $'\033['
+assert_contains "$ui_output" "0% 0/2 • first_step"
+assert_contains "$ui_output" "50% 1/2 ✓ first_step"
+assert_contains "$ui_output" "50% 1/2 • second_step"
+assert_contains "$ui_output" "100% 2/2 ✗ second_step"
+assert_contains "$ui_output" "$(tput csr 0 22)"
+assert_contains "$ui_output" "$(tput cup 23 0)"
+assert_contains "$ui_output" "$(tput csr 0 23)"
+if [ "$(wc -l <"$tmp/ui-output")" -ne 1 ]; then
+	printf '%s\n' 'FAIL: pinned progress emitted more than one terminal line'
 	exit 1
 fi
 if [ "${failed_functions[*]}" != second_step ]; then
@@ -82,67 +108,176 @@ if [ "$setup_status" -ne 1 ]; then
 	exit 1
 fi
 
+export LINES=24
+export COLUMNS=80
 failed_functions=()
 setup_progress_start first_step first_step
-adjacent_output="$(run_functions first_step first_step 2>&1)"
-if [[ "$adjacent_output" != *"50% 1/2 ✓ first_step"$'\r\033[2K'">>> first_step"* ]]; then
-	printf 'FAIL: adjacent function did not clear the live bar\n%s\n' "$adjacent_output"
+{
+	run_function first_step
+	export LINES=30
+	export COLUMNS=40
+	setup_progress_handle_resize
+	setup_progress_finish
+} >"$tmp/resize-output" 2>&1 9>"$tmp/resize-ui"
+resize_ui="$(<"$tmp/resize-ui")"
+assert_contains "$resize_ui" "$(LINES=24 tput csr 0 22)"
+assert_contains "$resize_ui" "$(LINES=30 tput csr 0 28)"
+assert_contains "$resize_ui" "$(LINES=30 tput cup 29 0)"
+if [ "$SETUP_PROGRESS_PINNED" -ne 0 ]; then
+	printf '%s\n' 'FAIL: progress footer remained pinned after finish'
 	exit 1
 fi
 
-failed_functions=()
-setup_progress_start fail_first first_step
-aggregate_output="$(run_functions fail_first first_step 2>&1)"
-if [[ "$aggregate_output" != *"100% 2/2 ✗ first_step"* ]]; then
-	printf 'FAIL: final progress lost an earlier failure\n%s\n' "$aggregate_output"
-	exit 1
-fi
-
-export COLUMNS=24
+export LINES=24
+export COLUMNS=80
+export PROFILE_SETUP_PROGRESS_STATE_FILE="$tmp/progress-state"
 failed_functions=()
 setup_progress_start first_step
-narrow_output="$(run_function first_step 2>&1)"
-narrow_line="$(printf '%s\n' "$narrow_output" | tail -n 1 | LC_ALL=C sed $'s/\033\\[[0-9;]*[A-Za-z]//g; s/\r//g')"
-if [ "${#narrow_line}" -gt "$COLUMNS" ]; then
-	printf 'FAIL: narrow-terminal progress is %d columns wide\n%s\n' "${#narrow_line}" "$narrow_line"
+run_function first_step >"$tmp/managed-output" 2>&1 9>"$tmp/managed-ui"
+if [ "$SETUP_PROGRESS_PINNED" -ne 1 ] ||
+	[[ "$(<"$tmp/progress-state")" != *"100% 1/1 ✓ first_step"* ]] ||
+	[[ "$(<"$tmp/managed-ui")" == *"$(tput csr 0 23)"* ]]; then
+	printf '%s\n' 'FAIL: managed progress did not defer teardown until tee drained'
+	exit 1
+fi
+unset PROFILE_SETUP_PROGRESS_STATE_FILE
+# shellcheck disable=SC2034 # Consumed by the sourced progress renderer.
+SETUP_PROGRESS_DEFER_FINISH=0
+setup_progress_restore_terminal force 9>>"$tmp/managed-ui"
+trap - WINCH
+
+export PROFILE_SETUP_PROGRESS_STATE_FILE="$tmp/fatal-progress-state"
+failed_functions=()
+setup_progress_start first_step
+setup_progress_begin first_step 9>"$tmp/fatal-managed-ui"
+setup_progress_restore_terminal force 9>>"$tmp/fatal-managed-ui"
+if [ -s "$PROFILE_SETUP_PROGRESS_STATE_FILE" ]; then
+	printf '%s\n' 'FAIL: restored fatal progress retained a stale managed footer'
+	exit 1
+fi
+unset PROFILE_SETUP_PROGRESS_STATE_FILE
+trap - WINCH
+
+export LINES=24
+export COLUMNS=80
+export PROFILE_SETUP_PROGRESS_STATE_FILE="$tmp/resized-progress-state"
+failed_functions=()
+setup_progress_start first_step first_step
+setup_progress_begin first_step 9>"$tmp/resized-managed-ui"
+if [ ! -s "$PROFILE_SETUP_PROGRESS_STATE_FILE" ]; then
+	printf '%s\n' 'FAIL: managed progress did not record its initial footer'
+	exit 1
+fi
+export COLUMNS=10
+setup_progress_handle_resize 9>>"$tmp/resized-managed-ui"
+if [ -s "$PROFILE_SETUP_PROGRESS_STATE_FILE" ]; then
+	printf '%s\n' 'FAIL: narrow resize retained a stale managed footer'
+	exit 1
+fi
+unset PROFILE_SETUP_PROGRESS_STATE_FILE
+
+export LINES=10
+export COLUMNS=24
+failed_functions=()
+setup_progress_start second_step
+setup_progress_pin 9>"$tmp/narrow-ui"
+# shellcheck disable=SC2034 # Consumed by the sourced progress renderer.
+SETUP_PROGRESS_FAILED=1
+setup_progress_build_line second_step OK
+narrow_line="$SETUP_PROGRESS_LINE"
+narrow_plain="$(printf '%s' "$narrow_line" | LC_ALL=C sed $'s/\033\\[[0-9;]*[A-Za-z]//g')"
+setup_progress_restore_terminal 9>>"$tmp/narrow-ui"
+trap - WINCH
+if [ "${#narrow_plain}" -gt "$COLUMNS" ]; then
+	printf 'FAIL: narrow progress is %d columns wide\n%s\n' "${#narrow_plain}" "$narrow_plain"
 	exit 1
 fi
 
+export COLUMNS=10
 export LC_ALL=C
 failed_functions=()
 setup_progress_start second_step
-narrow_ascii_output="$(run_function second_step 2>&1)"
-narrow_ascii_line="$(printf '%s\n' "$narrow_ascii_output" | tail -n 1 | LC_ALL=C sed $'s/\033\\[[0-9;]*[A-Za-z]//g; s/\r//g')"
-if [ "${#narrow_ascii_line}" -gt "$COLUMNS" ]; then
-	printf 'FAIL: narrow ASCII failure progress is %d columns wide\n%s\n' \
-		"${#narrow_ascii_line}" "$narrow_ascii_line"
+tiny_output="$(run_function second_step 9>"$tmp/tiny-ui" 2>&1)"
+tiny_line="$(printf '%s\n' "$tiny_output" | tail -n 1)"
+if [ "${#tiny_line}" -gt "$COLUMNS" ]; then
+	printf 'FAIL: tiny ASCII failure progress is %d columns wide\n%s\n' \
+		"${#tiny_line}" "$tiny_line"
 	exit 1
 fi
-export COLUMNS=80
-export LC_ALL="C.UTF-8"
 
-unset NO_COLOR
+export COLUMNS=1
 failed_functions=()
 setup_progress_start first_step
-colour_output="$(run_function first_step 2>&1)"
-if [[ "$colour_output" != *$'\033[1;92m'"━"* ]] ||
-	[[ "$colour_output" == *$'\033[38;2;'* ]]; then
-	printf 'FAIL: interactive progress is not Rich-style bright green\n%s\n' "$colour_output"
+one_column_output="$(run_function first_step 9>"$tmp/one-column-ui" 2>&1)"
+one_column_line="$(printf '%s\n' "$one_column_output" | tail -n 1)"
+if [ "${#one_column_line}" -gt "$COLUMNS" ]; then
+	printf 'FAIL: one-column progress is %d columns wide\n%s\n' \
+		"${#one_column_line}" "$one_column_line"
 	exit 1
 fi
 
+unset NO_COLOR
+export LINES=24
+export COLUMNS=80
+export LC_ALL="C.UTF-8"
+failed_functions=()
+setup_progress_start first_step
+run_function first_step >"$tmp/colour-output" 2>&1 9>"$tmp/colour-ui"
+colour_ui="$(<"$tmp/colour-ui")"
+assert_contains "$colour_ui" $'\033[1;92m━'
+assert_not_contains "$colour_ui" $'\033[38;2;'
+
+unset PROFILE_SETUP_PROGRESS_FD
 export PROFILE_SETUP_OUTPUT_TTY=0
 export LC_ALL=C
 failed_functions=()
 setup_progress_start first_step
 ascii_output="$(run_function first_step 2>&1)"
-if [[ "$ascii_output" != *"100% 1/1 OK first_step"* ]] ||
-	[[ "$ascii_output" != *"="* ]] ||
-	[[ "$ascii_output" == *"━"* ]] ||
-	[[ "$ascii_output" == *"✓"* ]] ||
-	[[ "$ascii_output" == *$'\033'* ]]; then
-	printf 'FAIL: non-interactive progress fallback is unstable\n%s\n' "$ascii_output"
+assert_contains "$ascii_output" "100% 1/1 OK first_step"
+assert_contains "$ascii_output" "="
+assert_not_contains "$ascii_output" "━"
+assert_not_contains "$ascii_output" "✓"
+assert_not_contains "$ascii_output" $'\033'
+
+failed_functions=()
+setup_progress_start fail_first first_step
+aggregate_output="$(run_functions fail_first first_step 2>&1)"
+assert_contains "$aggregate_output" "100% 2/2 FAIL first_step"
+
+keepalive_tree="$tmp/keepalive-tree"
+(
+	SUDO_KEEPALIVE_PID=""
+	# shellcheck disable=SC2329 # Invoked indirectly by keep_sudo_alive.
+	sudo_command() {
+		return 0
+	}
+	keep_sudo_alive
+	keepalive_pid="$SUDO_KEEPALIVE_PID"
+	sleep_pid=""
+	for _ in {1..50}; do
+		sleep_pid="$(ps -axo pid=,ppid=,comm= | awk -v parent="$keepalive_pid" \
+			'$2 == parent && $3 ~ /sleep/ { found = $1 } END { if (found) print found }')"
+		[ -n "$sleep_pid" ] && break
+		sleep 0.02
+	done
+	if [ -z "$sleep_pid" ]; then
+		printf '%s\n' 'FAIL: sudo keepalive sleep was not observable'
+		exit 1
+	fi
+	if [ -x /usr/sbin/lsof ] && /usr/sbin/lsof -a -p "$sleep_pid" -d 9 2>/dev/null | grep -q .; then
+		printf '%s\n' 'FAIL: sudo keepalive child inherited progress FD 9'
+		exit 1
+	fi
+	stop_sudo_keepalive
+	if kill -0 "$keepalive_pid" 2>/dev/null || kill -0 "$sleep_pid" 2>/dev/null; then
+		printf '%s\n' 'FAIL: stopping sudo keepalive left a descendant running'
+		exit 1
+	fi
+	printf '%s\n' 'KEEPALIVE_STOPPED' >"$keepalive_tree"
+) 9>"$tmp/keepalive-fd9"
+if [ "$(<"$keepalive_tree")" != KEEPALIVE_STOPPED ]; then
+	printf '%s\n' 'FAIL: sudo keepalive lifecycle test did not complete'
 	exit 1
 fi
 
-printf '%s\n' 'PASS: progress plans, phases, failures, and rendering work'
+printf '%s\n' 'PASS: one progress footer persists while raw setup output remains intact'

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -7,9 +7,9 @@ handle_error() {
 	echo "An error occurred on line $1"
 }
 
-# Prime the sudo timestamp once, then keep it warm in the background. Homebrew
-# 6 deliberately resets the timestamp when it starts, so privileged steps that
-# run after Homebrew use run_sudo and can re-prompt when necessary.
+# Prime the sudo timestamp once, then keep it warm in the background on Linux.
+# Homebrew deliberately resets the timestamp, so macOS uses foreground
+# run_sudo calls that can re-prompt when necessary.
 # - Idempotent: a second call is a no-op while a loop is already running.
 # - set -e / pipefail safe: the priming `sudo -v` is guarded with `|| return`,
 #   and the background loop's commands can't abort the parent shell.
@@ -17,31 +17,53 @@ handle_error() {
 #   the EXIT trap on error/early-exit paths, and is killed explicitly by
 #   exit_script before it returns or replaces the setup process.
 SUDO_KEEPALIVE_PID=""
+sudo_command() {
+	/usr/bin/sudo "$@"
+}
+
 keep_sudo_alive() {
+	local parent_pid=$$
+
 	# Already running? Do nothing.
 	if [ -n "$SUDO_KEEPALIVE_PID" ] && kill -0 "$SUDO_KEEPALIVE_PID" 2>/dev/null; then
 		return 0
 	fi
 	# Prompt for the password once (non-fatal under set -e if the user aborts).
-	sudo -v || return 1
+	sudo_command -v || return 1
 	# Explicitly extend the cached credentials until this script exits. Running
 	# an arbitrary sudo command does not reliably refresh the timestamp on macOS.
-	local parent_pid=$$
-	while true; do
-		/usr/bin/sudo -n -v 2>/dev/null || true
-		sleep 30
-		kill -0 "$parent_pid" 2>/dev/null || exit 0
-	done &
+	(
+		local sleep_pid=""
+		trap '[ -n "$sleep_pid" ] && kill "$sleep_pid" 2>/dev/null || true; exit 0' HUP INT TERM
+		while true; do
+			sudo_command -n -v 2>/dev/null || true
+			sleep 30 &
+			sleep_pid=$!
+			wait "$sleep_pid" 2>/dev/null || exit 0
+			sleep_pid=""
+			kill -0 "$parent_pid" 2>/dev/null || exit 0
+		done
+	) </dev/null >/dev/null 2>&1 9>&- &
 	SUDO_KEEPALIVE_PID=$!
 	# Reap the loop when the script exits (without clobbering the ERR trap).
-	trap 'kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true' EXIT
+	trap 'setup_progress_restore_terminal; stop_sudo_keepalive' EXIT
+}
+
+stop_sudo_keepalive() {
+	if [ -z "$SUDO_KEEPALIVE_PID" ]; then
+		return
+	fi
+	kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
+	wait "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
+	SUDO_KEEPALIVE_PID=""
 }
 
 run_sudo() {
-	if /usr/bin/sudo -n -v 2>/dev/null; then
-		/usr/bin/sudo -n "$@"
+	if sudo_command -n -v 2>/dev/null; then
+		sudo_command -n "$@"
 	else
-		/usr/bin/sudo "$@"
+		log "Administrator approval is required to continue."
+		sudo_command "$@"
 	fi
 }
 
@@ -59,22 +81,187 @@ ensure_directory() {
 
 SETUP_PROGRESS_CURRENT=0
 SETUP_PROGRESS_TOTAL=0
-SETUP_PROGRESS_VISIBLE=0
 SETUP_PROGRESS_FAILED=0
+SETUP_PROGRESS_PINNED=0
+SETUP_PROGRESS_ROWS=0
+SETUP_PROGRESS_COLUMNS=0
+SETUP_PROGRESS_LABEL=""
+SETUP_PROGRESS_STATE="RUN"
+SETUP_PROGRESS_LINE=""
+SETUP_PROGRESS_DEFER_FINISH=0
+SETUP_PROGRESS_CSR_PIN=""
+SETUP_PROGRESS_CSR_FULL=""
+SETUP_PROGRESS_CUP_OUTPUT=""
+SETUP_PROGRESS_CUP_FOOTER=""
+SETUP_PROGRESS_EL=""
+SETUP_PROGRESS_SC=""
+SETUP_PROGRESS_RC=""
 
 setup_progress_start() {
 	SETUP_PROGRESS_CURRENT=0
 	SETUP_PROGRESS_TOTAL="$#"
-	SETUP_PROGRESS_VISIBLE=0
 	SETUP_PROGRESS_FAILED=0
+	SETUP_PROGRESS_PINNED=0
+	SETUP_PROGRESS_LABEL=""
+	SETUP_PROGRESS_STATE="RUN"
+	SETUP_PROGRESS_LINE=""
+	SETUP_PROGRESS_DEFER_FINISH=0
 }
 
-setup_progress_clear() {
-	if [ "$SETUP_PROGRESS_VISIBLE" -ne 1 ]; then
+setup_progress_has_terminal() {
+	if [ "${PROFILE_SETUP_OUTPUT_TTY:-}" = 1 ] &&
+		[ "${PROFILE_SETUP_PROGRESS_FD:-}" = 9 ] &&
+		(: >&9) 2>/dev/null; then
+		return 0
+	fi
+	[ -z "${PROFILE_SETUP_OUTPUT_TTY:-}" ] && [ -t 1 ]
+}
+
+setup_progress_write() {
+	if [ "${PROFILE_SETUP_PROGRESS_FD:-}" = 9 ]; then
+		printf '%s' "$1" >&9 2>/dev/null || true
 		return
 	fi
-	printf '\r\033[2K'
-	SETUP_PROGRESS_VISIBLE=0
+	printf '%s' "$1" || true
+}
+
+setup_progress_read_dimensions() {
+	local size=""
+	local rows=""
+	local columns=""
+
+	if [ "${PROFILE_SETUP_PROGRESS_FD:-}" = 9 ]; then
+		size="$(stty size <&9 2>/dev/null || true)"
+	else
+		size="$(stty size 2>/dev/null || true)"
+	fi
+	rows="${size%% *}"
+	columns="${size##* }"
+	case "$rows" in
+	'' | *[!0-9]* | 0) rows="${LINES:-24}" ;;
+	esac
+	case "$columns" in
+	'' | *[!0-9]* | 0) columns="${COLUMNS:-80}" ;;
+	esac
+	case "$rows" in
+	'' | *[!0-9]*) rows=24 ;;
+	esac
+	case "$columns" in
+	'' | *[!0-9]*) columns=80 ;;
+	esac
+	SETUP_PROGRESS_ROWS="$rows"
+	SETUP_PROGRESS_COLUMNS="$columns"
+	if [ "$rows" -lt 3 ] || [ "$columns" -lt 12 ]; then
+		return 1
+	fi
+}
+
+setup_progress_read_capabilities() {
+	SETUP_PROGRESS_CSR_PIN="$(tput csr 0 "$((SETUP_PROGRESS_ROWS - 2))" 2>/dev/null)" || return 1
+	SETUP_PROGRESS_CSR_FULL="$(tput csr 0 "$((SETUP_PROGRESS_ROWS - 1))" 2>/dev/null)" || return 1
+	SETUP_PROGRESS_CUP_OUTPUT="$(tput cup "$((SETUP_PROGRESS_ROWS - 2))" 0 2>/dev/null)" || return 1
+	SETUP_PROGRESS_CUP_FOOTER="$(tput cup "$((SETUP_PROGRESS_ROWS - 1))" 0 2>/dev/null)" || return 1
+	SETUP_PROGRESS_EL="$(tput el 2>/dev/null)" || return 1
+	SETUP_PROGRESS_SC="$(tput sc 2>/dev/null)" || return 1
+	SETUP_PROGRESS_RC="$(tput rc 2>/dev/null)" || return 1
+}
+
+setup_progress_pin() {
+	local sequence
+
+	if [ "$SETUP_PROGRESS_PINNED" -eq 1 ]; then
+		return 0
+	fi
+	setup_progress_has_terminal || return 1
+	setup_progress_read_dimensions || return 1
+	[ "${TERM:-dumb}" != dumb ] || return 1
+	setup_progress_read_capabilities || return 1
+	sequence="${SETUP_PROGRESS_CSR_PIN}${SETUP_PROGRESS_CUP_OUTPUT}${SETUP_PROGRESS_EL}"
+	setup_progress_write "$sequence"
+	SETUP_PROGRESS_PINNED=1
+	trap 'setup_progress_handle_resize' WINCH
+}
+
+setup_progress_restore_terminal() {
+	local sequence
+
+	if [ "$SETUP_PROGRESS_PINNED" -ne 1 ]; then
+		return
+	fi
+	if [ -n "${PROFILE_SETUP_PROGRESS_STATE_FILE:-}" ] &&
+		[ "$SETUP_PROGRESS_DEFER_FINISH" -eq 1 ] && [ "${1:-}" != force ]; then
+		return
+	fi
+	sequence="${SETUP_PROGRESS_SC}${SETUP_PROGRESS_CUP_FOOTER}${SETUP_PROGRESS_EL}${SETUP_PROGRESS_CSR_FULL}${SETUP_PROGRESS_RC}"
+	setup_progress_write "$sequence"
+	SETUP_PROGRESS_PINNED=0
+	setup_progress_clear_recorded_state
+}
+
+setup_progress_finish() {
+	local sequence
+
+	if [ "$SETUP_PROGRESS_PINNED" -eq 1 ]; then
+		if [ -n "${PROFILE_SETUP_PROGRESS_STATE_FILE:-}" ]; then
+			SETUP_PROGRESS_DEFER_FINISH=1
+			return
+		fi
+		sequence="${SETUP_PROGRESS_CSR_FULL}${SETUP_PROGRESS_CUP_FOOTER}${SETUP_PROGRESS_EL}${SETUP_PROGRESS_LINE}"$'\n'
+		setup_progress_write "$sequence"
+		SETUP_PROGRESS_PINNED=0
+	fi
+	trap - WINCH
+}
+
+setup_progress_handle_resize() {
+	local label="$SETUP_PROGRESS_LABEL"
+	local state="$SETUP_PROGRESS_STATE"
+	local old_cup_footer="$SETUP_PROGRESS_CUP_FOOTER"
+	local sequence
+
+	if ! setup_progress_read_dimensions || ! setup_progress_read_capabilities; then
+		sequence=$'\033[r'"${old_cup_footer}${SETUP_PROGRESS_EL}"
+		setup_progress_write "$sequence"
+		SETUP_PROGRESS_PINNED=0
+		setup_progress_clear_recorded_state
+		trap - WINCH
+		return
+	fi
+	sequence="${SETUP_PROGRESS_CSR_FULL}${old_cup_footer}${SETUP_PROGRESS_EL}${SETUP_PROGRESS_CUP_FOOTER}${SETUP_PROGRESS_EL}${SETUP_PROGRESS_CSR_PIN}${SETUP_PROGRESS_CUP_OUTPUT}"
+	setup_progress_write "$sequence"
+	setup_progress_render "$label" "$state"
+}
+
+setup_progress_clear_recorded_state() {
+	if [ -z "${PROFILE_SETUP_PROGRESS_STATE_FILE:-}" ]; then
+		return
+	fi
+	if ! : >|"$PROFILE_SETUP_PROGRESS_STATE_FILE" 2>/dev/null; then
+		PROFILE_SETUP_PROGRESS_STATE_FILE=""
+	fi
+}
+
+setup_progress_record_state() {
+	local summary_state="OK"
+	local summary
+
+	if [ -z "${PROFILE_SETUP_PROGRESS_STATE_FILE:-}" ]; then
+		return
+	fi
+	if [ "$SETUP_PROGRESS_STATE" = RUN ] && [ "$SETUP_PROGRESS_FAILED" -eq 0 ]; then
+		summary_state="RUN"
+	elif [ "$SETUP_PROGRESS_FAILED" -ne 0 ]; then
+		summary_state="FAIL"
+	fi
+	summary="$SETUP_PROGRESS_CURRENT/$SETUP_PROGRESS_TOTAL $summary_state $SETUP_PROGRESS_LABEL"
+	if ! {
+		printf '%s\n' "$SETUP_PROGRESS_ROWS"
+		printf '%s\n' "$SETUP_PROGRESS_COLUMNS"
+		printf '%s\n' "$SETUP_PROGRESS_LINE"
+		printf '%s\n' "$summary"
+	} 2>/dev/null >|"$PROFILE_SETUP_PROGRESS_STATE_FILE"; then
+		PROFILE_SETUP_PROGRESS_STATE_FILE=""
+	fi
 }
 
 run_functions() {
@@ -85,9 +272,9 @@ run_functions() {
 	done
 }
 
-setup_progress_advance() {
+setup_progress_build_line() {
 	local label="$1"
-	local exit_code="$2"
+	local state="$2"
 	local width=28
 	local filled
 	local remaining
@@ -96,18 +283,17 @@ setup_progress_advance() {
 	local completed_bar=""
 	local remaining_bar=""
 	local head=""
-	local symbol="OK"
+	local symbol="RUN"
 	local bar_colour=""
 	local remaining_colour=""
 	local status_colour=""
 	local colour_reset=""
-	local output_tty="${PROFILE_SETUP_OUTPUT_TTY:-}"
 	local locale="${LC_ALL:-${LC_CTYPE:-${LANG:-}}}"
 	local completed_char="="
 	local remaining_char="-"
 	local head_char=">"
 	local unicode_output=0
-	local live_output=0
+	local live_output="$SETUP_PROGRESS_PINNED"
 	local live_label="$label"
 	local compact_output=0
 	local display_status
@@ -117,28 +303,11 @@ setup_progress_advance() {
 	local terminal_columns
 	local progress_line
 
-	if [ "$SETUP_PROGRESS_TOTAL" -le 0 ]; then
-		return
-	fi
-	SETUP_PROGRESS_CURRENT=$((SETUP_PROGRESS_CURRENT + 1))
 	percent=$((SETUP_PROGRESS_CURRENT * 100 / SETUP_PROGRESS_TOTAL))
 	count="${SETUP_PROGRESS_CURRENT}/${SETUP_PROGRESS_TOTAL}"
-	if [ "$exit_code" -ne 0 ]; then
-		SETUP_PROGRESS_FAILED=1
-	fi
-	if [ -z "$output_tty" ]; then
-		if [ -t 1 ]; then
-			output_tty=1
-		else
-			output_tty=0
-		fi
-	fi
-	if [ "$output_tty" -eq 1 ] && [ "${TERM:-dumb}" != dumb ]; then
-		live_output=1
-	fi
 	case "$locale" in
 	*[Uu][Tt][Ff]-8* | *[Uu][Tt][Ff]8*)
-		if [ "$output_tty" -eq 1 ]; then
+		if [ "$live_output" -eq 1 ]; then
 			unicode_output=1
 			completed_char="━"
 			remaining_char="━"
@@ -146,26 +315,32 @@ setup_progress_advance() {
 		fi
 		;;
 	esac
-	display_status="$exit_code"
-	if [ "$live_output" -eq 1 ]; then
-		display_status="$SETUP_PROGRESS_FAILED"
-	fi
-	if [ "$display_status" -ne 0 ]; then
+	display_status="$SETUP_PROGRESS_FAILED"
+	if [ "$state" = RUN ] && [ "$display_status" -eq 0 ]; then
+		symbol="RUN"
+	elif [ "$display_status" -ne 0 ]; then
 		symbol="FAIL"
+	else
+		symbol="OK"
 	fi
 	if [ "$unicode_output" -eq 1 ]; then
-		if [ "$display_status" -eq 0 ]; then
+		if [ "$state" = RUN ] && [ "$display_status" -eq 0 ]; then
+			symbol="•"
+		elif [ "$display_status" -eq 0 ]; then
 			symbol="✓"
 		else
 			symbol="✗"
 		fi
 	fi
-	if [ "$live_output" -eq 1 ]; then
-		terminal_columns="${COLUMNS:-}"
-		case "$terminal_columns" in
-		'' | *[!0-9]* | 0) terminal_columns="$(tput cols 2>/dev/null || printf '80')" ;;
-		esac
-		fixed_width=$((9 + ${#count} + ${#symbol}))
+	if [ "$live_output" -eq 1 ] ||
+		{ [ "${PROFILE_SETUP_OUTPUT_TTY:-}" = 1 ] && [ "$SETUP_PROGRESS_COLUMNS" -gt 0 ]; } ||
+		{ [ -z "${PROFILE_SETUP_OUTPUT_TTY:-}" ] && [ -t 1 ] && [ "$SETUP_PROGRESS_COLUMNS" -gt 0 ]; }; then
+		terminal_columns="$SETUP_PROGRESS_COLUMNS"
+		if [ "$terminal_columns" -le "${#count}" ]; then
+			SETUP_PROGRESS_LINE="${count:0:terminal_columns}"
+			return
+		fi
+		fixed_width=$((10 + ${#count} + ${#symbol}))
 		if [ "$terminal_columns" -lt $((fixed_width + width + 1 + ${#live_label})) ]; then
 			live_label=""
 		fi
@@ -194,7 +369,7 @@ setup_progress_advance() {
 		remaining_bar+="$remaining_char"
 	done
 
-	if [ "$output_tty" -eq 1 ] && [ "${TERM:-dumb}" != dumb ] && [ -z "${NO_COLOR:-}" ]; then
+	if [ "$live_output" -eq 1 ] && [ -z "${NO_COLOR:-}" ]; then
 		bar_colour=$'\033[1;92m'
 		remaining_colour=$'\033[90m'
 		colour_reset=$'\033[0m'
@@ -218,17 +393,49 @@ setup_progress_advance() {
 			"$colour_reset" "$percent" "$count" "$status_colour" "$symbol" "$colour_reset" \
 			"$live_label"
 	fi
-	if [ "$live_output" -eq 0 ]; then
-		printf '%s\n' "$progress_line"
+	SETUP_PROGRESS_LINE="$progress_line"
+}
+
+setup_progress_render() {
+	local sequence
+
+	SETUP_PROGRESS_LABEL="$1"
+	SETUP_PROGRESS_STATE="$2"
+	setup_progress_build_line "$1" "$2"
+	sequence="${SETUP_PROGRESS_SC}${SETUP_PROGRESS_CUP_FOOTER}${SETUP_PROGRESS_EL}${SETUP_PROGRESS_LINE}${SETUP_PROGRESS_RC}"
+	setup_progress_write "$sequence"
+	setup_progress_record_state
+}
+
+setup_progress_begin() {
+	if [ "$SETUP_PROGRESS_TOTAL" -le 0 ]; then
 		return
 	fi
-	if [ "$SETUP_PROGRESS_CURRENT" -eq "$SETUP_PROGRESS_TOTAL" ]; then
-		printf '\r\033[2K%s\n' "$progress_line"
-		SETUP_PROGRESS_VISIBLE=0
+	if setup_progress_pin; then
+		setup_progress_render "$1" RUN
+	fi
+}
+
+setup_progress_advance() {
+	local label="$1"
+	local exit_code="$2"
+
+	if [ "$SETUP_PROGRESS_TOTAL" -le 0 ]; then
 		return
 	fi
-	printf '\r\033[2K%s' "$progress_line"
-	SETUP_PROGRESS_VISIBLE=1
+	SETUP_PROGRESS_CURRENT=$((SETUP_PROGRESS_CURRENT + 1))
+	if [ "$exit_code" -ne 0 ]; then
+		SETUP_PROGRESS_FAILED=1
+	fi
+	if [ "$SETUP_PROGRESS_PINNED" -eq 1 ]; then
+		setup_progress_render "$label" OK
+		if [ "$SETUP_PROGRESS_CURRENT" -eq "$SETUP_PROGRESS_TOTAL" ]; then
+			setup_progress_finish
+		fi
+		return
+	fi
+	setup_progress_build_line "$label" OK
+	printf '%s\n' "$SETUP_PROGRESS_LINE"
 }
 
 # Evaluate the Homebrew shellenv matching the current architecture.
@@ -243,7 +450,7 @@ brew_shellenv() {
 }
 
 collect_user_input() {
-	# Gather all interactive input upfront so the rest of the setup is unattended
+	# Gather optional profile values before package installation.
 	GIT_USER_NAME=$(git config --global user.name 2>/dev/null) || GIT_USER_NAME=""
 	GIT_USER_EMAIL=$(git config --global user.email 2>/dev/null) || GIT_USER_EMAIL=""
 	GIT_USER_PHONE=$(git config --global user.phonenumber 2>/dev/null) || GIT_USER_PHONE=""
@@ -260,7 +467,7 @@ collect_user_input() {
 		GIT_USER_PHONE="$input"
 	fi
 	echo ""
-	log "All input collected. Setup will now run unattended."
+	log "All profile input collected. Setup will continue."
 }
 
 run_function() {
@@ -276,7 +483,7 @@ run_function() {
 	*e*) had_errexit=1 ;;
 	esac
 
-	setup_progress_clear
+	setup_progress_begin "$func_name"
 	if command -v gum >/dev/null 2>&1; then
 		gum style --foreground 212 --bold ">>> $func_name"
 	else
@@ -289,7 +496,11 @@ run_function() {
 		set -e
 		set -o pipefail
 		trap 'handle_error $LINENO' ERR
-		"$func_name"
+		if [ "${PROFILE_SETUP_PROGRESS_FD:-}" = 9 ]; then
+			"$func_name" 9>&-
+		else
+			"$func_name"
+		fi
 	)
 	exit_code=$?
 	if [ "$had_errexit" -eq 1 ]; then
@@ -529,7 +740,7 @@ exit_script() {
 	print_function_name
 	local setup_status=0
 	# Stop the sudo keepalive explicitly before returning or replacing this process.
-	[ -n "$SUDO_KEEPALIVE_PID" ] && kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || true
+	stop_sudo_keepalive
 	ensure_directory
 	if [ ${#failed_functions[@]} -eq 0 ]; then
 		echo "==============================="

--- a/tools/macos_helpers.sh
+++ b/tools/macos_helpers.sh
@@ -1,5 +1,22 @@
 #!/bin/bash
-# macOS system-tool validation helpers, isolated for focused tests.
+# macOS helpers isolated for focused tests.
+
+cask_auto_updates() {
+	brew info --cask "$1" 2>/dev/null | sed -n '1p' | grep -q '(auto_updates)'
+}
+
+casks_managed_by_own_updater() {
+	local cask
+	local selected=""
+
+	for cask in "$@"; do
+		if brew list --versions --cask "$cask" &>/dev/null &&
+			cask_auto_updates "$cask" && ! cask_has_missing_app_artifact "$cask"; then
+			selected="${selected:+$selected }$cask"
+		fi
+	done
+	printf '%s\n' "$selected"
+}
 
 clt_receipt_exists() {
 	/usr/sbin/pkgutil --pkg-info=com.apple.pkg.CLTools_Executables &>/dev/null
@@ -31,7 +48,7 @@ move_stale_command_line_tools() {
 
 	stale_clt_backup="${clt_dir}.stale-$(date '+%Y%m%d%H%M%S').$$"
 	log "Moving stale standalone Command Line Tools to $stale_clt_backup"
-	/usr/bin/sudo -n /bin/mv "$clt_dir" "$stale_clt_backup"
+	run_sudo /bin/mv "$clt_dir" "$stale_clt_backup"
 }
 
 command_line_tools_are_current() {

--- a/tools/setup_macos.sh
+++ b/tools/setup_macos.sh
@@ -9,9 +9,10 @@ export PATH="/usr/local/sbin:$PATH"
 export PATH="$HOME/.local/bin:$PATH"
 export PROFILE_DIR=$(pwd)
 export ARCHITECTURE=$(uname -m)
-# Upstream installers should use the sudo ticket primed below and must not stop
-# for their own confirmation prompts. Homebrew CLI ask mode is now the default;
-# HOMEBREW_NO_ASK disables it, while NONINTERACTIVE covers its bootstrap script.
+# Upstream installers must not stop for their own confirmation prompts.
+# Homebrew may still request administrator approval after it deliberately
+# invalidates sudo. HOMEBREW_NO_ASK disables its CLI ask mode, while
+# NONINTERACTIVE covers its bootstrap script.
 export NONINTERACTIVE=1
 export HOMEBREW_NO_ASK=1
 export GIT_TERMINAL_PROMPT=0
@@ -23,11 +24,10 @@ set -o pipefail
 source "$PROFILE_DIR/tools/common.sh"
 source "$PROFILE_DIR/tools/macos_helpers.sh"
 trap 'handle_error $LINENO' ERR
+trap 'setup_progress_restore_terminal' EXIT
 
-# Prompt for sudo once, then keep the timestamp warm for the whole install.
-keep_sudo_alive
-
-# Use the Homebrew matching the current architecture
+# Use the Homebrew matching the current architecture. Privileged steps request
+# approval only when needed because Homebrew invalidates cached sudo tickets.
 brew_shellenv
 
 install_command_line_tools() {
@@ -63,17 +63,24 @@ install_command_line_tools() {
 		clt_update_required=true
 	fi
 
+	# A valid full Xcode is preferable to reinstalling optional standalone tools.
+	# Validate that Homebrew accepts it, then remove only the stale CLT directory.
+	if [ "$clt_update_required" = true ] && [ "$full_xcode_available" = true ] &&
+		use_full_xcode_for_invalid_command_line_tools "$full_xcode_available"; then
+		clt_update_required=false
+	fi
+
 	if [ "$clt_update_required" = true ]; then
 		log "Searching for Xcode Command Line Tools..."
 		# This marker makes softwareupdate include the standalone CLT package even
 		# when Xcode or an older CLT is already selected.
-		/usr/bin/sudo -n /usr/bin/touch "$clt_placeholder"
+		run_sudo /usr/bin/touch "$clt_placeholder"
 		clt_label="$(command_line_tools_label_if_required "$clt_update_required")" || true
-		/usr/bin/sudo -n /bin/rm -f "$clt_placeholder"
+		run_sudo /bin/rm -f "$clt_placeholder"
 
 		if [ -n "$clt_label" ]; then
 			log "Installing $clt_label..."
-			if ! /usr/bin/sudo -n /usr/sbin/softwareupdate --install "$clt_label" --agree-to-license; then
+			if ! run_sudo /usr/sbin/softwareupdate --install "$clt_label" --agree-to-license; then
 				log "softwareupdate did not install $clt_label; validating the active toolchain."
 			fi
 		fi
@@ -87,7 +94,7 @@ install_command_line_tools() {
 
 	# Select the standalone CLT directory after a first-time headless install.
 	if [ "$clt_missing" = true ] && [ -d /Library/Developer/CommandLineTools ]; then
-		/usr/bin/sudo -n /usr/bin/xcode-select --switch /Library/Developer/CommandLineTools
+		run_sudo /usr/bin/xcode-select --switch /Library/Developer/CommandLineTools
 	fi
 
 	if ! xcode-select -p &>/dev/null; then
@@ -282,13 +289,14 @@ install_packages() {
 		fi
 	done
 	local unwanted_casks=("julia-app" "julia")
-	local caskroom="$(brew --prefix)/Caskroom"
+	local caskroom
+	caskroom="$(brew --prefix)/Caskroom"
 	for cask in "${unwanted_casks[@]}"; do
 		if brew uninstall --cask --force "$cask" 2>/dev/null; then
 			log "Removed unwanted cask: $cask"
 		elif [ -d "$caskroom/$cask" ]; then
 			log "Removing stale cask metadata: $cask"
-			rm -rf "$caskroom/$cask"
+			rm -rf "${caskroom:?}/$cask"
 		fi
 	done
 
@@ -315,7 +323,9 @@ install_packages() {
 	taps="$(brew bundle list --file="$brewfile" --tap | tr '\n' ' ')"
 	local bundle_failed=0
 	local cask
+	local installed_auto_update_casks=""
 
+	log "Homebrew may request administrator approval for privileged cask installers."
 	# Repair incomplete installations that Homebrew's receipt-only checks miss.
 	for cask in $casks; do
 		if brew list --versions --cask "$cask" &>/dev/null; then
@@ -343,6 +353,7 @@ install_packages() {
 			fi
 		fi
 	done
+	installed_auto_update_casks="$(casks_managed_by_own_updater $casks)"
 
 	if ! HOMEBREW_BUNDLE_CASK_SKIP="$casks" HOMEBREW_BUNDLE_MAS_SKIP="$mas_apps" \
 		brew bundle --file="$brewfile"; then
@@ -350,7 +361,8 @@ install_packages() {
 		bundle_failed=1
 	fi
 	if ! HOMEBREW_BUNDLE_BREW_SKIP="$formulae" HOMEBREW_BUNDLE_MAS_SKIP="$mas_apps" \
-		HOMEBREW_BUNDLE_TAP_SKIP="$taps" brew bundle --file="$brewfile"; then
+		HOMEBREW_BUNDLE_TAP_SKIP="$taps" HOMEBREW_BUNDLE_CASK_SKIP="$installed_auto_update_casks" \
+		brew bundle --file="$brewfile"; then
 		log "Warning: Homebrew cask installation reported errors; continuing..."
 		bundle_failed=1
 	fi
@@ -657,9 +669,9 @@ main() {
 	if ! xcode-select -p &>/dev/null; then
 		clt_was_missing=true
 		run_functions "${preflight_steps[@]}"
-		setup_progress_clear
 		# Git cannot read the existing identity until this required preflight succeeds.
 		if [ ${#failed_functions[@]} -ne 0 ]; then
+			setup_progress_finish
 			return 1
 		fi
 	fi
@@ -670,7 +682,6 @@ main() {
 		before_brew_steps=("${preflight_steps[@]}" "${before_brew_steps[@]}")
 	fi
 	run_functions "${before_brew_steps[@]}"
-	setup_progress_clear
 	# run_function isolates each step so errors are reliable. Refresh the
 	# environment changes made by install_homebrew in the parent shell.
 	brew_shellenv

--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -1035,7 +1035,6 @@ main() {
 
 	# copy_dotfiles must run first — it sources .bash_aliases which defines apt_upgrader
 	run_functions "${bootstrap_steps[@]}"
-	setup_progress_clear
 	# run_function isolates setup steps so failures cannot be masked. Source the
 	# copied aliases in the parent as well because later steps use apt_upgrader.
 	if [ -f "$HOME/.bash_aliases" ]; then


### PR DESCRIPTION
Pin progress below live setup output, make macOS CLT recovery safe after Homebrew resets sudo, and isolate installed self-updating casks from transient upgrades.

## Summary by Sourcery

Stabilize interactive setup output and macOS recovery while isolating self-updating applications from transient Homebrew upgrades.

New Features:
- Pin interactive setup progress to the terminal footer while preserving chronological setup output in logs.
- Add resilient macOS setup recovery that can re-prompt for sudo, prefer valid full Xcode tooling, and exclude validated installed self-updating casks from bundle upgrades.

Bug Fixes:
- Prevent terminal control sequences, progress state, and inherited progress file descriptors from leaking into setup logs or child processes.
- Handle terminal resizing, setup failures, interruptions, and Homebrew sudo timestamp invalidation without leaving stale progress or privileged-operation state.

Enhancements:
- Improve sudo keepalive lifecycle management and retain newline-based progress output for non-interactive runs.

Documentation:
- Document the pinned live progress behavior, macOS sudo recovery model, and self-updating cask handling.

Tests:
- Expand progress, logging, PTY, macOS recovery, descriptor isolation, resizing, and sudo keepalive regression coverage.