### PR TITLE
fix(setup): configure terminal input preferences

### DIFF
--- a/dotfiles/.inputrc
+++ b/dotfiles/.inputrc
@@ -1,0 +1,4 @@
+$include /etc/inputrc
+
+# Complete paths without requiring matching letter case.
+set completion-ignore-case on

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -6,7 +6,7 @@
 - [x] Add and run focused regression coverage.
 - [x] Run repository shell checks.
 - [x] Obtain an independent review and resolve its findings.
-- [ ] Raise a pull request.
+- [x] Raise a pull request.
 
 ## Review
 
@@ -21,6 +21,7 @@
       portability failure in this Linux environment.
 - [x] Independent review found no correctness, scope, idempotence,
       cross-platform Readline, GNOME, test-quality, or prose issues.
+- [x] Raised pull request #219 and left merging to a human.
 
 # Simplify setup output and remove Julia cleanup
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,27 @@
+# Configure terminal input preferences
+
+- [x] Confirm the working case-insensitive completion setting on this machine.
+- [x] Manage the Readline preference consistently on Ubuntu and macOS.
+- [x] Enable GNOME primary-selection paste during Ubuntu setup.
+- [x] Add and run focused regression coverage.
+- [x] Run repository shell checks.
+- [x] Obtain an independent review and resolve its findings.
+- [ ] Raise a pull request.
+
+## Review
+
+- [x] Added one managed Readline file for both platforms and removed Ubuntu's
+      ineffective system-wide mutation.
+- [x] Added primary-selection paste to the existing idempotent GNOME settings.
+- [x] Verified the focused preference regression, Readline's loaded value,
+      Bash syntax, shell formatting, and all relevant existing tests.
+- [x] Confirmed the changed scripts introduce no new ShellCheck finding codes;
+      repository-wide lint retains unrelated existing findings.
+- [x] `tests/setup_logging/run.sh` retains an unrelated GNU `stat -f`
+      portability failure in this Linux environment.
+- [x] Independent review found no correctness, scope, idempotence,
+      cross-platform Readline, GNOME, test-quality, or prose issues.
+
 # Simplify setup output and remove Julia cleanup
 
 - [x] Remove loading and progress output from macOS and Ubuntu.

--- a/tests/setup_preferences/run.sh
+++ b/tests/setup_preferences/run.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$here/../.." && pwd)"
+ubuntu_setup="$repo_root/tools/setup_ubuntu.sh"
+macos_setup="$repo_root/tools/setup_macos.sh"
+
+# shellcheck disable=SC2016 # The literal Readline directive is intentional.
+if ! grep -Fxq '$include /etc/inputrc' "$repo_root/dotfiles/.inputrc" ||
+	! grep -Fxq 'set completion-ignore-case on' "$repo_root/dotfiles/.inputrc"; then
+	printf '%s\n' 'FAIL: managed inputrc does not enable case-insensitive completion'
+	exit 1
+fi
+
+for setup in "$ubuntu_setup" "$macos_setup"; do
+	# shellcheck disable=SC2016 # The production variable references are intentional.
+	if ! grep -Fq 'cp "$PROFILE_DIR/dotfiles/.inputrc" "$HOME/.inputrc"' "$setup"; then
+		printf 'FAIL: %s does not install the managed inputrc\n' "$setup"
+		exit 1
+	fi
+done
+
+if grep -Fq '/etc/inputrc' "$ubuntu_setup"; then
+	printf '%s\n' 'FAIL: Ubuntu setup still modifies the system inputrc'
+	exit 1
+fi
+
+if ! grep -Fq \
+	'gsettings set org.gnome.desktop.interface gtk-enable-primary-paste true' \
+	"$ubuntu_setup"; then
+	printf '%s\n' 'FAIL: Ubuntu setup does not enable middle-click paste'
+	exit 1
+fi
+
+printf '%s\n' 'PASS: terminal input preferences are configured'

--- a/tools/setup_macos.sh
+++ b/tools/setup_macos.sh
@@ -112,6 +112,7 @@ copy_dotfiles() {
 	cp "$PROFILE_DIR/dotfiles/.bashrc" "$HOME/.bashrc"
 	cp "$PROFILE_DIR/dotfiles/.prettierrc" "$HOME/.prettierrc"
 	cp "$PROFILE_DIR/dotfiles/.bash_aliases" "$HOME/.bash_aliases"
+	cp "$PROFILE_DIR/dotfiles/.inputrc" "$HOME/.inputrc"
 
 	# Helper scripts that .bash_aliases shells out to (keeps the sourced
 	# .bash_aliases small/fast). Same path is used on macOS and Linux.
@@ -166,10 +167,6 @@ copy_dotfiles() {
 	mkdir -p "$iterm2_profiles_dir"
 	cp "$PROFILE_DIR/dotfiles/iterm2/terminator-style.json" "$iterm2_profiles_dir/terminator-style.json"
 
-	# Case-insensitive tab completion
-	if [ ! -f "$HOME/.inputrc" ] || ! grep -q 'completion-ignore-case' "$HOME/.inputrc" 2>/dev/null; then
-		echo 'set completion-ignore-case On' >>"$HOME/.inputrc"
-	fi
 }
 
 install_homebrew() {

--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -33,6 +33,7 @@ copy_dotfiles() {
 	cp $PROFILE_DIR/dotfiles/.bashrc $HOME/.bashrc
 	cp $PROFILE_DIR/dotfiles/.prettierrc $HOME/.prettierrc
 	cp $PROFILE_DIR/dotfiles/.bash_aliases $HOME/.bash_aliases
+	cp "$PROFILE_DIR/dotfiles/.inputrc" "$HOME/.inputrc"
 
 	# Helper scripts that .bash_aliases shells out to (keeps the sourced
 	# .bash_aliases small/fast). Same path is used on macOS and Linux.
@@ -43,10 +44,6 @@ copy_dotfiles() {
 	chmod +x "$HOME/.local/bin/work-proxy"
 
 	copy_btop_config
-	# Case-insensitive tab completion (idempotent)
-	if ! grep -q 'completion-ignore-case' /etc/inputrc 2>/dev/null; then
-		echo 'set completion-ignore-case On' | sudo tee -a /etc/inputrc
-	fi
 	# Source .bash_aliases so apt_upgrader (defined there) is available to later functions
 	source $HOME/.bash_aliases
 }
@@ -684,6 +681,7 @@ configure_gnome() {
 	if command -v gsettings >/dev/null 2>&1; then
 		gsettings set org.gnome.desktop.interface text-scaling-factor 0.95
 		gsettings set org.gnome.desktop.interface cursor-size 24
+		gsettings set org.gnome.desktop.interface gtk-enable-primary-paste true
 	fi
 }
 


### PR DESCRIPTION
Enable GNOME middle-click paste and install shared case-insensitive Readline completion settings.

## Summary by Sourcery

Configure consistent terminal input preferences across supported setup platforms.

New Features:
- Enable GNOME primary-selection paste during Ubuntu setup.

Bug Fixes:
- Apply case-insensitive Readline completion consistently across Ubuntu and macOS using a shared managed configuration.

Tests:
- Add focused regression coverage for Readline and GNOME terminal preference setup.