### PR TITLE
build(ubuntu): install D-Bus development dependencies

### DIFF
--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -66,6 +66,7 @@ install_apt_packages() {
 		gnuplot \
 		imagemagick \
 		libbz2-dev \
+		libdbus-1-dev \
 		libffi-dev \
 		liblzma-dev \
 		libncursesw5-dev \
@@ -81,6 +82,7 @@ install_apt_packages() {
 		m4 \
 		moreutils \
 		openssh-server \
+		pkg-config \
 		python3-pip \
 		shellcheck \
 		tk-dev \


### PR DESCRIPTION
Installs the native D-Bus and pkg-config dependencies required to build Rust keyring consumers on Ubuntu.

## Summary by Sourcery

Build:
- Add Ubuntu setup dependencies for building Rust keyring consumers with D-Bus support.