### PR TITLE
fix(ubuntu): use British date formatting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ again; never cache or broker the administrator password in setup code.
 ```bash
 shellcheck tools/setup_macos.sh tools/setup_ubuntu.sh tools/common.sh tools/macos_helpers.sh setup_entry.sh
 shfmt -d tools/setup_macos.sh tools/setup_ubuntu.sh tools/common.sh tools/macos_helpers.sh setup_entry.sh
+bash tests/setup_preferences/run.sh
 bash tests/setup_logging/run.sh
 bash tests/setup_macos/run.sh
 bash tests/setup_runner/run.sh

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,23 @@
+# Use British date formatting on Ubuntu
+
+- [x] Inspect the existing Ubuntu locale and GNOME preference setup.
+- [x] Persist the British system locale and GNOME region during setup.
+- [x] Add focused regression coverage.
+- [x] Run repository shell checks and focused tests.
+- [x] Obtain an independent review and resolve its findings.
+- [ ] Raise a pull request.
+
+## Review
+
+- [x] Added an idempotent Ubuntu setup step that generates `en_GB.UTF-8` only
+      when absent, persists it with `update-locale`, and sets the GNOME region.
+- [x] Verified the focused preference regression, Bash syntax, shell formatting,
+      the British `%d/%m/%y` locale pattern, and the macOS and runner suites.
+- [x] The repository-wide ShellCheck command retains unrelated existing findings.
+      The logging suite retains its documented GNU `stat -f` portability failure.
+- [x] Independent review found no correctness or idempotency issues. Added the
+      focused preference regression to the repository's documented checks.
+
 # Configure terminal input preferences
 
 - [x] Confirm the working case-insensitive completion setting on this machine.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -5,7 +5,7 @@
 - [x] Add focused regression coverage.
 - [x] Run repository shell checks and focused tests.
 - [x] Obtain an independent review and resolve its findings.
-- [ ] Raise a pull request.
+- [x] Raise a pull request.
 
 ## Review
 
@@ -17,6 +17,7 @@
       The logging suite retains its documented GNU `stat -f` portability failure.
 - [x] Independent review found no correctness or idempotency issues. Added the
       focused preference regression to the repository's documented checks.
+- [x] Raised pull request #221 and left merging to a human.
 
 # Configure terminal input preferences
 

--- a/tests/setup_preferences/run.sh
+++ b/tests/setup_preferences/run.sh
@@ -33,4 +33,19 @@ if ! grep -Fq \
 	exit 1
 fi
 
-printf '%s\n' 'PASS: terminal input preferences are configured'
+for locale_setting in \
+	'sudo locale-gen en_GB.UTF-8' \
+	'sudo update-locale LANG=en_GB.UTF-8' \
+	"gsettings set org.gnome.system.locale region 'en_GB.UTF-8'"; do
+	if ! grep -Fq "$locale_setting" "$ubuntu_setup"; then
+		printf 'FAIL: Ubuntu setup is missing locale setting: %s\n' "$locale_setting"
+		exit 1
+	fi
+done
+
+if ! grep -Fqx $'\t\tconfigure_locale' "$ubuntu_setup"; then
+	printf '%s\n' 'FAIL: Ubuntu setup does not run locale configuration'
+	exit 1
+fi
+
+printf '%s\n' 'PASS: terminal input and locale preferences are configured'

--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -687,6 +687,17 @@ configure_gnome() {
 	fi
 }
 
+configure_locale() {
+	print_function_name
+	if ! locale -a | grep -Eiq '^en_GB\.utf-?8$'; then
+		sudo locale-gen en_GB.UTF-8
+	fi
+	sudo update-locale LANG=en_GB.UTF-8
+	if command -v gsettings >/dev/null 2>&1; then
+		gsettings set org.gnome.system.locale region 'en_GB.UTF-8'
+	fi
+}
+
 install_ghostty() {
 	print_function_name
 	# Install / upgrade Ghostty via the mkasberg community .deb, which tracks
@@ -1022,6 +1033,7 @@ main() {
 		install_duf
 		install_gum
 		install_ghostty
+		configure_locale
 		configure_gnome
 		install_delta
 		install_lazygit


### PR DESCRIPTION
Persist the British system locale and GNOME regional date format during Ubuntu setup.

## Summary by Sourcery

Use British locale and regional date formatting for Ubuntu setup.

Bug Fixes:
- Configure Ubuntu installations to use the British `en_GB.UTF-8` system locale and GNOME regional date settings.

Documentation:
- Document the focused Ubuntu preference regression test in the repository's standard checks.

Tests:
- Add regression coverage verifying Ubuntu locale configuration is invoked and includes the required British locale settings.