### PR TITLE
fix(ghostty): manage macOS copy-on-select config

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,25 @@
+# Enable Ghostty copy-on-select on macOS
+
+- [x] Confirm Ghostty's macOS clipboard setting and effective configuration.
+- [x] Install the shared config at Ghostty's canonical macOS path.
+- [x] Add focused regression coverage for both platform destinations.
+- [x] Apply and validate the managed config on the current Mac.
+- [x] Run shell checks and obtain an independent review.
+
+## Review
+
+- [x] macOS setup writes `config.ghostty` to Ghostty's higher-precedence
+      Application Support directory, then removes only the old profile-managed
+      XDG file so stale or additive settings are not loaded twice.
+- [x] The current Mac uses the canonical file, validates it successfully, and
+      resolves one config with `copy-on-select = clipboard`.
+- [x] The preference, logging, macOS, and runner suites pass, as do Bash syntax,
+      formatting, the changed-test ShellCheck, and `git diff --check`.
+- [x] Repository-wide ShellCheck retains unrelated existing findings, including
+      the Ubuntu `inline=false` error.
+- [x] Independent review's migration and missing-file test findings were fixed;
+      the final review found no remaining material issues.
+
 # Use British date formatting on Ubuntu
 
 - [x] Inspect the existing Ubuntu locale and GNOME preference setup.

--- a/tests/setup_preferences/run.sh
+++ b/tests/setup_preferences/run.sh
@@ -5,6 +5,35 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$here/../.." && pwd)"
 ubuntu_setup="$repo_root/tools/setup_ubuntu.sh"
 macos_setup="$repo_root/tools/setup_macos.sh"
+ghostty_config="$repo_root/dotfiles/ghostty/config"
+
+if [ ! -f "$ghostty_config" ] ||
+	[ "$(grep -Fxc 'copy-on-select = clipboard' "$ghostty_config")" -ne 1 ]; then
+	printf '%s\n' 'FAIL: managed Ghostty config does not copy selections to the system clipboard'
+	exit 1
+fi
+
+# shellcheck disable=SC2016 # The production variable references are intentional.
+if ! grep -Fq \
+	'local ghostty_config_dir="$HOME/Library/Application Support/com.mitchellh.ghostty"' \
+	"$macos_setup" ||
+	! grep -Fq \
+		'cp "$PROFILE_DIR/dotfiles/ghostty/config" "$ghostty_config_dir/config.ghostty"' \
+		"$macos_setup" ||
+	! grep -Fq \
+		'rm -f "$HOME/.config/ghostty/config"' \
+		"$macos_setup"; then
+	printf '%s\n' 'FAIL: macOS setup does not install the managed Ghostty config at its canonical path'
+	exit 1
+fi
+
+# shellcheck disable=SC2016 # The production variable references are intentional.
+if ! grep -Fq \
+	'cp $PROFILE_DIR/dotfiles/ghostty/config $HOME/.config/ghostty/config' \
+	"$ubuntu_setup"; then
+	printf '%s\n' 'FAIL: Ubuntu setup does not install the managed Ghostty config'
+	exit 1
+fi
 
 # shellcheck disable=SC2016 # The literal Readline directive is intentional.
 if ! grep -Fxq '$include /etc/inputrc' "$repo_root/dotfiles/.inputrc" ||
@@ -48,4 +77,4 @@ if ! grep -Fqx $'\t\tconfigure_locale' "$ubuntu_setup"; then
 	exit 1
 fi
 
-printf '%s\n' 'PASS: terminal input and locale preferences are configured'
+printf '%s\n' 'PASS: terminal input, Ghostty, and locale preferences are configured'

--- a/tools/setup_macos.sh
+++ b/tools/setup_macos.sh
@@ -124,9 +124,12 @@ copy_dotfiles() {
 
 	copy_btop_config
 
-	# Ghostty config (shared between macOS and Linux)
-	mkdir -p "$HOME/.config/ghostty"
-	cp "$PROFILE_DIR/dotfiles/ghostty/config" "$HOME/.config/ghostty/config"
+	# Ghostty loads this macOS-specific location after its XDG config.
+	local ghostty_config_dir="$HOME/Library/Application Support/com.mitchellh.ghostty"
+	mkdir -p "$ghostty_config_dir"
+	cp "$PROFILE_DIR/dotfiles/ghostty/config" "$ghostty_config_dir/config.ghostty"
+	# Do not load the legacy file previously managed by this profile as well.
+	rm -f "$HOME/.config/ghostty/config"
 
 	# Disable custom prefs folder (fragile — breaks if repo path changes)
 	defaults write com.googlecode.iterm2 LoadPrefsFromCustomFolder -bool false


### PR DESCRIPTION
Manage Ghostty's canonical macOS config path, migrate the legacy copy safely, and cover copy-on-select setup on both platforms.

## Summary by Sourcery

Configure Ghostty copy-on-select consistently across macOS and Ubuntu while safely migrating the macOS configuration path.

Bug Fixes:
- Install Ghostty's managed configuration at the canonical macOS location and remove the legacy XDG configuration to prevent duplicate or stale settings.
- Ensure copy-on-select is configured for the system clipboard on macOS and Ubuntu.

Tests:
- Add regression coverage verifying Ghostty configuration content and platform-specific installation destinations.