### PR TITLE
feat(setup): add professional progress display

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,12 @@ Set `PROFILE_SETUP_LOG_DIR` to an absolute path to override the directory.
 Logs and their parent directory are mode `600` and `700` respectively.
 Treat them as private and never commit them.
 
+Interactive runs show one animated row for the active function and an exact
+overall function-count bar beneath it. Completed rows and detailed command
+output scroll above the footer and are written chronologically to the private
+log. Administrator prompts stay in the foreground. Non-interactive runs retain
+plain output.
+
 Each platform's `main` defines its executable function plan. The shared runner
 records failed functions and continues with the remaining steps.
 

--- a/setup_entry.sh
+++ b/setup_entry.sh
@@ -49,6 +49,9 @@ profile_setup_main() {
 	local setup_status
 	local tee_status
 	local had_pipefail=0
+	local output_tty=0
+	local terminal_rows
+	local terminal_size
 
 	case "${XDG_STATE_HOME:-}" in
 	/*) state_home="$XDG_STATE_HOME" ;;
@@ -106,12 +109,20 @@ profile_setup_main() {
 		unset -f profile_setup_run profile_setup_main
 		return 1
 	fi
+	if [ -t 9 ]; then
+		output_tty=1
+	fi
 	if set -o | grep -Eq '^pipefail[[:space:]]+on$'; then
 		had_pipefail=1
 		set +o pipefail
 	fi
 	if (
 		set +e
+		export PROFILE_SETUP_OUTPUT_TTY="$output_tty"
+		if [ "$output_tty" -eq 1 ]; then
+			export PROFILE_SETUP_PROGRESS_FD=9
+			export PROFILE_SETUP_DEFER_PROGRESS_FINISH=1
+		fi
 		profile_setup_run
 		setup_status=$?
 		printf '%s\n' "$setup_status" >|"$status_file"
@@ -120,6 +131,14 @@ profile_setup_main() {
 		tee_status=0
 	else
 		tee_status=$?
+	fi
+	if [ "$output_tty" -eq 1 ]; then
+		terminal_size="$(stty size <&9 2>/dev/null || true)"
+		terminal_rows=${terminal_size%% *}
+		case "$terminal_rows" in
+		'' | *[!0-9]* | 0) printf '\033[r\n' >&9 || true ;;
+		*) printf '\033[r\033[%d;1H\n' "$terminal_rows" >&9 || true ;;
+		esac
 	fi
 	if [ "$had_pipefail" -eq 1 ]; then
 		set -o pipefail
@@ -150,7 +169,7 @@ profile_setup_main() {
 	fi
 
 	# Start the replacement login shell only after tee has closed the log.
-	bash -l
+	bash -l 9>&-
 }
 
-profile_setup_main
+profile_setup_main 9>&1

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -5,8 +5,11 @@ Update this file whenever a correction reveals a rule worth keeping.
 
 ## Setup output
 
-Do not add a loading or progress bar. Keep plain newline-delimited function
-boundaries so terminal output and persisted logs remain readable and reliable.
+Interactive progress must stay separate from the private log. Keep completed
+function rows, use an indeterminate state when a function exposes no measurable
+progress, and reserve percentages for the exact overall function count. Suspend
+or isolate animation so foreground prompts cannot be overwritten, and retain
+plain output when no terminal is available.
 
 ## Keep guards proportional
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,24 @@
+# Add professional setup progress
+
+- [x] Inspect the current runner and earlier progress implementations.
+- [x] Restore coloured per-function start, success, and failure states.
+- [x] Show an animated row for each function and one live overall progress bar.
+- [x] Keep full command output in the private log without terminal cursor codes.
+- [x] Preserve prompts, failures, non-interactive output, and terminal cleanup.
+- [x] Run local shell and pseudo-terminal verification.
+- [x] Obtain an independent final review and resolve its findings.
+
+## Review
+
+- [x] Interactive terminals keep an animated function row and exact overall
+      footer while ordinary output and prompts scroll above it; completed rows
+      remain visible and the private log contains no cursor controls.
+- [x] Verified success, failure continuation, foreground prompts, `NO_COLOR`,
+      non-interactive fallback, narrow terminals, resizes, signal cleanup,
+      deferred entry-point cleanup, log modes, and the absence of tracked tests.
+- [x] Bash 3.2 syntax, shfmt, error-level ShellCheck, and `git diff --check` pass.
+      Independent macOS and Ubuntu reviews found no remaining issue.
+
 # Skip the Tailscale installer over SSH
 
 - [x] Add one early SSH guard to Ubuntu's Tailscale installer.

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -43,10 +43,8 @@ keep_sudo_alive() {
 			sleep_pid=""
 			kill -0 "$parent_pid" 2>/dev/null || exit 0
 		done
-	) </dev/null >/dev/null 2>&1 &
+	) </dev/null >/dev/null 2>&1 9>&- &
 	SUDO_KEEPALIVE_PID=$!
-	# Reap the loop when the script exits (without clobbering the ERR trap).
-	trap 'stop_sudo_keepalive' EXIT
 }
 
 stop_sudo_keepalive() {
@@ -69,6 +67,349 @@ run_sudo() {
 
 log() {
 	echo -e "$(date '+%Y-%m-%d %H:%M:%S') - $1"
+}
+
+SETUP_PROGRESS_CURRENT=0
+SETUP_PROGRESS_TOTAL=0
+SETUP_PROGRESS_FAILED=0
+SETUP_PROGRESS_ENABLED=0
+SETUP_PROGRESS_PINNED=0
+SETUP_PROGRESS_SPINNER_PID=""
+SETUP_PROGRESS_STARTED=0
+SETUP_PROGRESS_STEP_STARTED=0
+SETUP_PROGRESS_STEP_LABEL=""
+SETUP_PROGRESS_STEP_STATE=run
+SETUP_PROGRESS_ROWS=0
+SETUP_PROGRESS_COLUMNS=0
+SETUP_PROGRESS_LABEL_WIDTH=28
+SETUP_PROGRESS_BAR_WIDTH=24
+SETUP_PROGRESS_BLUE=""
+SETUP_PROGRESS_GREEN=""
+SETUP_PROGRESS_RED=""
+SETUP_PROGRESS_MUTED=""
+SETUP_PROGRESS_RESET=""
+
+setup_progress_start() {
+	SETUP_PROGRESS_CURRENT=0
+	SETUP_PROGRESS_TOTAL=$#
+	SETUP_PROGRESS_FAILED=0
+	SETUP_PROGRESS_ENABLED=0
+	SETUP_PROGRESS_PINNED=0
+	SETUP_PROGRESS_SPINNER_PID=""
+	SETUP_PROGRESS_STARTED=$SECONDS
+	SETUP_PROGRESS_BLUE=""
+	SETUP_PROGRESS_GREEN=""
+	SETUP_PROGRESS_RED=""
+	SETUP_PROGRESS_MUTED=""
+	SETUP_PROGRESS_RESET=""
+
+	if [ "$SETUP_PROGRESS_TOTAL" -gt 0 ] &&
+		[ "${PROFILE_SETUP_OUTPUT_TTY:-0}" = 1 ] &&
+		[ "${PROFILE_SETUP_PROGRESS_FD:-}" = 9 ] &&
+		[ "${TERM:-dumb}" != dumb ] &&
+		(: >&9) 2>/dev/null; then
+		SETUP_PROGRESS_ENABLED=1
+	fi
+	if [ "$SETUP_PROGRESS_ENABLED" -eq 1 ] && [ -z "${NO_COLOR:-}" ]; then
+		SETUP_PROGRESS_BLUE=$'\033[38;2;108;142;168m'
+		SETUP_PROGRESS_GREEN=$'\033[38;2;155;179;150m'
+		SETUP_PROGRESS_RED=$'\033[38;2;237;158;152m'
+		SETUP_PROGRESS_MUTED=$'\033[38;2;106;102;94m'
+		SETUP_PROGRESS_RESET=$'\033[0m'
+	fi
+}
+
+setup_progress_write() {
+	printf '%b' "$@" >&9 2>/dev/null || true
+}
+
+setup_progress_read_dimensions() {
+	local size rows columns label_width=28 bar_width=24
+
+	size="$(stty size <&9 2>/dev/null)" || return 1
+	rows=${size%% *}
+	columns=${size##* }
+	case "$rows:$columns" in
+	*[!0-9:]* | :* | *:) return 1 ;;
+	esac
+	SETUP_PROGRESS_ROWS=$rows
+	SETUP_PROGRESS_COLUMNS=$columns
+	if [ "$rows" -lt 5 ] || [ "$columns" -lt 46 ]; then
+		return 1
+	fi
+	if [ "$columns" -lt 78 ]; then
+		label_width=20
+		bar_width=$((columns - label_width - 26))
+		if [ "$bar_width" -lt 8 ]; then
+			label_width=$((label_width - 8 + bar_width))
+			bar_width=8
+		fi
+	fi
+	SETUP_PROGRESS_LABEL_WIDTH=$label_width
+	SETUP_PROGRESS_BAR_WIDTH=$bar_width
+}
+
+setup_progress_clear_footer() {
+	local rows=$1
+
+	if [ "$rows" -ge 2 ]; then
+		setup_progress_write "\033[$((rows - 1));1H"$'\033[2K' \
+			"\033[${rows};1H"$'\033[2K'
+	fi
+}
+
+setup_progress_apply_pin() {
+	local output_row=$((SETUP_PROGRESS_ROWS - 2))
+	local step_row=$((SETUP_PROGRESS_ROWS - 1))
+
+	setup_progress_write $'\033[r'"\033[${step_row};1H"$'\033[2K' \
+		"\033[${SETUP_PROGRESS_ROWS};1H"$'\033[2K' \
+		"\033[1;${output_row}r\033[${output_row};1H"
+	SETUP_PROGRESS_PINNED=1
+}
+
+setup_progress_pin() {
+	setup_progress_read_dimensions || return 1
+	setup_progress_apply_pin
+}
+
+setup_progress_restore() {
+	local step_row=$((SETUP_PROGRESS_ROWS - 1))
+
+	if [ "$SETUP_PROGRESS_PINNED" -ne 1 ]; then
+		return
+	fi
+	setup_progress_write $'\033[r'
+	setup_progress_clear_footer "$SETUP_PROGRESS_ROWS"
+	setup_progress_write "\033[${step_row};1H"
+	SETUP_PROGRESS_PINNED=0
+}
+
+setup_progress_refresh_dimensions() {
+	local old_rows=$SETUP_PROGRESS_ROWS
+	local old_columns=$SETUP_PROGRESS_COLUMNS
+
+	if ! setup_progress_read_dimensions; then
+		setup_progress_write $'\033[r'
+		setup_progress_clear_footer "$old_rows"
+		setup_progress_clear_footer "$SETUP_PROGRESS_ROWS"
+		if [ "$SETUP_PROGRESS_ROWS" -ge 2 ]; then
+			setup_progress_write "\033[$((SETUP_PROGRESS_ROWS - 1));1H"
+		fi
+		SETUP_PROGRESS_PINNED=0
+		SETUP_PROGRESS_ENABLED=0
+		return 1
+	fi
+	if [ "$old_rows" -ne "$SETUP_PROGRESS_ROWS" ] ||
+		[ "$old_columns" -ne "$SETUP_PROGRESS_COLUMNS" ]; then
+		setup_progress_write $'\033[r'
+		setup_progress_clear_footer "$old_rows"
+		setup_progress_apply_pin
+	fi
+}
+
+setup_progress_line() {
+	local kind=$1 state=$2 tick=${3:-0}
+	local width=$SETUP_PROGRESS_BAR_WIDTH pulse_width=5 ix filled=0 position=0
+	local started="$SETUP_PROGRESS_STEP_STARTED"
+	local label=${SETUP_PROGRESS_STEP_LABEL//_/ }
+	local colour="$SETUP_PROGRESS_BLUE" icon="●" suffix
+	local bar="" bar_colour char timer padded_label percent=0
+
+	if [ "$kind" = overall ]; then
+		started="$SETUP_PROGRESS_STARTED"
+		label=Overall
+		icon="◆"
+		filled=$((SETUP_PROGRESS_CURRENT * width / SETUP_PROGRESS_TOTAL))
+		percent=$((SETUP_PROGRESS_CURRENT * 100 / SETUP_PROGRESS_TOTAL))
+		if [ "$SETUP_PROGRESS_CURRENT" -eq "$SETUP_PROGRESS_TOTAL" ]; then
+			state=ok
+			[ "$SETUP_PROGRESS_FAILED" -ne 0 ] && state=fail
+		fi
+	elif [ "$state" = run ]; then
+		position=$((tick % ((width - pulse_width) * 2)))
+		if [ "$position" -gt $((width - pulse_width)) ]; then
+			position=$(((width - pulse_width) * 2 - position))
+		fi
+	fi
+	case "$state" in
+	ok)
+		colour="$SETUP_PROGRESS_GREEN"
+		icon="✓"
+		filled=$width
+		;;
+	fail)
+		colour="$SETUP_PROGRESS_RED"
+		icon="✗"
+		filled=$width
+		;;
+	esac
+	for ((ix = 0; ix < width; ix++)); do
+		bar_colour="$SETUP_PROGRESS_MUTED"
+		char="─"
+		if { [ "$kind" = overall ] && [ "$ix" -lt "$filled" ]; } ||
+			{ [ "$kind" = step ] && [ "$state" != run ]; } ||
+			{ [ "$kind" = step ] && [ "$ix" -ge "$position" ] && [ "$ix" -lt $((position + pulse_width)) ]; }; then
+			bar_colour="$colour"
+			char="━"
+		fi
+		bar="${bar}${bar_colour}${char}"
+	done
+	printf -v timer '%d:%02d:%02d' \
+		$(((SECONDS - started) / 3600)) \
+		$((((SECONDS - started) % 3600) / 60)) $(((SECONDS - started) % 60))
+	if [ "$kind" = overall ]; then
+		printf -v suffix '%3d%% %d/%d %s' "$percent" "$SETUP_PROGRESS_CURRENT" \
+			"$SETUP_PROGRESS_TOTAL" "$timer"
+	elif [ "$state" = run ]; then
+		suffix=$timer
+	elif [ "$state" = ok ]; then
+		suffix="100% $timer"
+	else
+		suffix="FAIL $timer"
+	fi
+	printf -v padded_label "%-${SETUP_PROGRESS_LABEL_WIDTH}.${SETUP_PROGRESS_LABEL_WIDTH}s" "$label"
+	printf -v SETUP_PROGRESS_LINE '  %b%s%b %b%s%b %s%b %s' \
+		"$colour" "$icon" "$SETUP_PROGRESS_RESET" "$colour" "$padded_label" \
+		"$SETUP_PROGRESS_RESET" "$bar" "$SETUP_PROGRESS_RESET" "$suffix"
+}
+
+setup_progress_render() {
+	local tick=${1:-0}
+	local step_row=$((SETUP_PROGRESS_ROWS - 1))
+	local step_line
+
+	setup_progress_line step "$SETUP_PROGRESS_STEP_STATE" "$tick"
+	step_line=$SETUP_PROGRESS_LINE
+	setup_progress_line overall run
+	setup_progress_write $'\0337'"\033[${step_row};1H"$'\033[2K'"${step_line}" \
+		"\033[${SETUP_PROGRESS_ROWS};1H"$'\033[2K'"${SETUP_PROGRESS_LINE}"$'\0338'
+}
+
+setup_progress_begin_step() {
+	local parent_pid=$$
+
+	if [ "$SETUP_PROGRESS_ENABLED" -ne 1 ]; then
+		return 1
+	fi
+	if [ "$SETUP_PROGRESS_PINNED" -ne 1 ] && ! setup_progress_pin; then
+		SETUP_PROGRESS_ENABLED=0
+		return 1
+	fi
+	SETUP_PROGRESS_STEP_LABEL=$1
+	SETUP_PROGRESS_STEP_STARTED=$SECONDS
+	SETUP_PROGRESS_STEP_STATE=run
+	setup_progress_render 0
+	(
+		local tick=0
+		while kill -0 "$parent_pid" 2>/dev/null; do
+			sleep 0.2
+			tick=$((tick + 1))
+			if [ $((tick % 5)) -eq 0 ]; then
+				setup_progress_refresh_dimensions || exit 0
+			fi
+			setup_progress_render "$tick"
+		done
+	) </dev/null >/dev/null 2>&1 &
+	SETUP_PROGRESS_SPINNER_PID=$!
+}
+
+setup_progress_stop_spinner() {
+	if [ -z "$SETUP_PROGRESS_SPINNER_PID" ]; then
+		return
+	fi
+	kill "$SETUP_PROGRESS_SPINNER_PID" 2>/dev/null || true
+	wait "$SETUP_PROGRESS_SPINNER_PID" 2>/dev/null || true
+	SETUP_PROGRESS_SPINNER_PID=""
+}
+
+setup_progress_complete_step() {
+	local label=$1
+	local exit_code=$2
+	local state=ok
+
+	setup_progress_stop_spinner
+	SETUP_PROGRESS_CURRENT=$((SETUP_PROGRESS_CURRENT + 1))
+	if [ "$exit_code" -ne 0 ]; then
+		SETUP_PROGRESS_FAILED=$((SETUP_PROGRESS_FAILED + 1))
+		state=fail
+	fi
+	SETUP_PROGRESS_STEP_LABEL=$label
+	SETUP_PROGRESS_STEP_STATE=$state
+	if setup_progress_refresh_dimensions; then
+		setup_progress_render
+		setup_progress_line step "$state"
+		printf '%s\n' "$SETUP_PROGRESS_LINE"
+	else
+		setup_step_message "$state" "$label"
+	fi
+}
+
+setup_progress_pause() {
+	setup_progress_stop_spinner
+	setup_progress_restore
+}
+
+setup_progress_finish() {
+	local step_row
+	local overall_line
+
+	setup_progress_stop_spinner
+	if [ "$SETUP_PROGRESS_PINNED" -eq 1 ]; then
+		setup_progress_refresh_dimensions || true
+	fi
+	if [ "$SETUP_PROGRESS_PINNED" -eq 1 ]; then
+		setup_progress_line overall run
+		overall_line=$SETUP_PROGRESS_LINE
+		if [ "${PROFILE_SETUP_DEFER_PROGRESS_FINISH:-0}" = 1 ]; then
+			setup_progress_render
+			SETUP_PROGRESS_ENABLED=0
+			return
+		fi
+		step_row=$((SETUP_PROGRESS_ROWS - 1))
+		setup_progress_write $'\033[r'"\033[${step_row};1H"$'\033[2K' \
+			"\033[${SETUP_PROGRESS_ROWS};1H"$'\033[2K' \
+			"\033[${step_row};1H${overall_line}"$'\n'
+	fi
+	SETUP_PROGRESS_PINNED=0
+	SETUP_PROGRESS_ENABLED=0
+}
+
+setup_progress_interrupt() {
+	local status=$1
+	PROFILE_SETUP_DEFER_PROGRESS_FINISH=0
+	setup_progress_finish
+	exit "$status"
+}
+
+setup_progress_install_traps() {
+	trap 'setup_progress_finish; stop_sudo_keepalive' EXIT
+	trap 'setup_progress_interrupt 129' HUP
+	trap 'setup_progress_interrupt 130' INT
+	trap 'setup_progress_interrupt 143' TERM
+}
+
+setup_step_message() {
+	local state=$1
+	local label=$2
+	local colour=""
+	local reset=""
+	local message=">>> $label"
+
+	case "$state" in
+	ok) message="<<< $label done" ;;
+	fail) message="FAIL $label" ;;
+	esac
+	if { [ -t 1 ] || [ "${PROFILE_SETUP_OUTPUT_TTY:-0}" = 1 ]; } &&
+		[ "${TERM:-dumb}" != dumb ] && [ -z "${NO_COLOR:-}" ]; then
+		reset=$'\033[0m'
+		case "$state" in
+		start) colour=$'\033[38;2;108;142;168m' ;;
+		ok) colour=$'\033[38;2;155;179;150m' ;;
+		fail) colour=$'\033[38;2;237;158;152m' ;;
+		esac
+	fi
+	printf '%b%s%b\n' "$colour" "$message" "$reset"
 }
 
 run_functions() {
@@ -114,6 +455,7 @@ collect_user_input() {
 run_function() {
 	local func_name=$1 exit_code=0
 	local had_errexit=0
+	local progress_enabled=0
 
 	# Calling a function directly from `cmd || ...` disables errexit for every
 	# command in that function. Run it in a subshell instead so the first
@@ -124,11 +466,10 @@ run_function() {
 	*e*) had_errexit=1 ;;
 	esac
 
-	if command -v gum >/dev/null 2>&1; then
-		gum style --foreground 212 --bold ">>> $func_name"
-	else
-		echo ">>> $func_name"
+	if setup_progress_begin_step "$func_name"; then
+		progress_enabled=1
 	fi
+	setup_step_message start "$func_name"
 
 	set +e
 	(
@@ -137,7 +478,7 @@ run_function() {
 		set -o pipefail
 		trap 'handle_error $LINENO' ERR
 		"$func_name"
-	)
+	) 9>&-
 	exit_code=$?
 	if [ "$had_errexit" -eq 1 ]; then
 		set -e
@@ -145,15 +486,13 @@ run_function() {
 
 	if [ "$exit_code" -ne 0 ]; then
 		failed_functions+=("$func_name")
-		if command -v gum >/dev/null 2>&1; then
-			gum style --foreground 196 --bold "FAIL $func_name"
-		else
-			echo "Warning: $func_name failed, continuing with next function..."
-		fi
-	elif command -v gum >/dev/null 2>&1; then
-		gum style --foreground 82 --bold "<<< $func_name done"
+	fi
+	if [ "$progress_enabled" -eq 1 ]; then
+		setup_progress_complete_step "$func_name" "$exit_code"
+	elif [ "$exit_code" -ne 0 ]; then
+		setup_step_message fail "$func_name"
 	else
-		echo "<<< $func_name done"
+		setup_step_message ok "$func_name"
 	fi
 	return 0
 }
@@ -376,6 +715,7 @@ install_ai() {
 
 exit_script() {
 	local setup_status=0
+	setup_progress_finish
 	# Stop the sudo keepalive explicitly before returning or replacing this process.
 	stop_sudo_keepalive
 	cd "$PROFILE_DIR"

--- a/tools/setup_macos.sh
+++ b/tools/setup_macos.sh
@@ -20,7 +20,8 @@ set -o pipefail
 source "$PROFILE_DIR/tools/common.sh"
 # shellcheck disable=SC1091
 source "$PROFILE_DIR/tools/macos_helpers.sh"
-trap 'handle_error $LINENO' ERR
+setup_progress_install_traps
+trap 'setup_progress_finish; handle_error $LINENO' ERR
 
 # Use the Homebrew matching the current architecture. Privileged steps request
 # approval only when needed because Homebrew invalidates cached sudo tickets.
@@ -613,16 +614,24 @@ main() {
 		install_syncthing
 		install_ai
 	)
+	local setup_steps=(
+		"${preflight_steps[@]}"
+		"${before_brew_steps[@]}"
+		"${after_brew_steps[@]}"
+	)
 	failed_functions=()
+	setup_progress_start "${setup_steps[@]}"
 	if ! xcode-select -p &>/dev/null; then
 		clt_was_missing=true
 		run_functions "${preflight_steps[@]}"
 		# Git cannot read the existing identity until this required preflight succeeds.
 		if [ ${#failed_functions[@]} -ne 0 ]; then
+			setup_progress_finish
 			return 1
 		fi
 	fi
 
+	setup_progress_pause
 	collect_user_input
 
 	if [ "$clt_was_missing" = false ]; then
@@ -634,6 +643,7 @@ main() {
 	brew_shellenv
 	export HOMEBREW_NO_AUTO_UPDATE=1
 	run_functions "${after_brew_steps[@]}"
+	setup_progress_finish
 
 	# Report failures if any
 	if [ ${#failed_functions[@]} -ne 0 ]; then

--- a/tools/setup_ubuntu.sh
+++ b/tools/setup_ubuntu.sh
@@ -10,7 +10,8 @@ set -e
 set -o pipefail
 
 source "$PROFILE_DIR/tools/common.sh"
-trap 'handle_error $LINENO' ERR
+setup_progress_install_traps
+trap 'setup_progress_finish; handle_error $LINENO' ERR
 
 # Prompt for sudo once, then keep the timestamp warm for the whole install.
 keep_sudo_alive
@@ -893,6 +894,8 @@ main() {
 		install_ai
 		apt_upgrader
 	)
+	local setup_steps=(copy_dotfiles "${remaining_steps[@]}")
+	setup_progress_start "${setup_steps[@]}"
 
 	# Copy the aliases before loading apt_upgrader into the parent shell.
 	run_function copy_dotfiles
@@ -902,6 +905,7 @@ main() {
 		source "$HOME/.bash_aliases"
 	fi
 	run_functions "${remaining_steps[@]}"
+	setup_progress_finish
 
 	# Report failures if any
 	if [ ${#failed_functions[@]} -ne 0 ]; then


### PR DESCRIPTION
Adds coloured per-function progress with a prompt-safe overall footer while preserving chronological setup logs.

## Summary by Sourcery

Provide setup scripts with a prompt-safe interactive progress display while preserving readable logs and plain non-interactive output.

New Features:
- Add an interactive terminal progress display with coloured per-function status rows, animated active steps, and an exact overall function-count footer.

Bug Fixes:
- Keep progress rendering out of persisted setup logs and prevent it from overwriting administrator prompts or leaving terminal state corrupted.
- Preserve plain newline-delimited output for non-interactive terminals and support graceful handling of failures, signals, terminal resizing, narrow screens, and NO_COLOR.

Enhancements:
- Centralize setup progress lifecycle, rendering, terminal cleanup, and signal handling across macOS and Ubuntu setup flows.
- Retain chronological setup output and completed function results while pausing the display around foreground user input.

Documentation:
- Document interactive progress behavior, prompt handling, private logging, and non-interactive output expectations.

Tests:
- Record verification of interactive, non-interactive, prompt, failure, signal, resize, colour, and terminal cleanup behavior.

Chores:
- Close out the setup progress implementation and review checklist.