### PR TITLE
fix(setup): show progress on first ssh run

### DIFF
--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -11,6 +11,11 @@ progress, and reserve percentages for the exact overall function count. Suspend
 or isolate animation so foreground prompts cannot be overwritten, and retain
 plain output when no terminal is available.
 
+A self-updating run can combine an old entry point in memory with new platform
+scripts on disk. Shared terminal features must not rely solely on state exported
+by the entry point. Treat a reserved progress descriptor as usable only when it
+is a terminal; an SSH shell can inherit the same descriptor number for logging.
+
 ## Keep guards proportional
 
 When asked to skip one installer in a particular context, add the direct guard

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -15,6 +15,8 @@ A self-updating run can combine an old entry point in memory with new platform
 scripts on disk. Shared terminal features must not rely solely on state exported
 by the entry point. Treat a reserved progress descriptor as usable only when it
 is a terminal; an SSH shell can inherit the same descriptor number for logging.
+Use the controlling terminal directly rather than replacing an inherited
+non-terminal descriptor, and preserve it inside setup function subprocesses.
 
 ## Keep guards proportional
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,29 @@
+# Show setup progress on the first post-update run
+
+- [x] Confirm `ssh_current` allocates a terminal and diagnose the Ubuntu path.
+- [x] Let the updated runner acquire the controlling terminal when the old
+      entry point did not pass one through.
+- [x] Preserve the non-interactive fallback and close only runner-owned file
+      descriptors.
+- [x] Run Bash 3.2, pseudo-terminal, no-terminal, formatting, and lint checks.
+- [x] Obtain an independent review and resolve its findings.
+
+## Review
+
+- [x] Ubuntu's latest setup run predated the merged progress change, and the
+      checkout therefore still contains the old renderer-free code.
+- [x] The updated runner acquires `/dev/tty` only when descriptor 9 is not
+      already a terminal, then closes only the terminal descriptor it opened.
+      Existing entry-point and non-interactive paths retain their previous
+      ownership and output.
+- [x] Verified the old-entry pipeline in a Bash 3.2 pseudo-terminal, the
+      deferred current-entry path, plain no-terminal output, and descriptor
+      cleanup. Reproduced the missing bars through `ssh_current alex-work`,
+      then verified the corrected animation in Ubuntu's non-interactive child
+      and `tee` path with an inherited non-terminal descriptor 9. Bash syntax,
+      shfmt, ShellCheck, and `git diff --check` pass.
+- [x] An independent Ubuntu review found no remaining issue.
+
 # Add professional setup progress
 
 - [x] Inspect the current runner and earlier progress implementations.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -3,8 +3,7 @@
 - [x] Confirm `ssh_current` allocates a terminal and diagnose the Ubuntu path.
 - [x] Let the updated runner acquire the controlling terminal when the old
       entry point did not pass one through.
-- [x] Preserve the non-interactive fallback and close only runner-owned file
-      descriptors.
+- [x] Preserve inherited file descriptors and the non-interactive fallback.
 - [x] Run Bash 3.2, pseudo-terminal, no-terminal, formatting, and lint checks.
 - [x] Obtain an independent review and resolve its findings.
 
@@ -12,10 +11,10 @@
 
 - [x] Ubuntu's latest setup run predated the merged progress change, and the
       checkout therefore still contains the old renderer-free code.
-- [x] The updated runner acquires `/dev/tty` only when descriptor 9 is not
-      already a terminal, then closes only the terminal descriptor it opened.
-      Existing entry-point and non-interactive paths retain their previous
-      ownership and output.
+- [x] The updated runner uses `/dev/tty` directly, leaving inherited logging
+      and IPC descriptors intact. Non-interactive runs retain plain output.
+- [x] Setup functions close descriptor 9 only when it is the marked progress
+      terminal; direct-terminal and non-interactive functions preserve it.
 - [x] Verified the old-entry pipeline in a Bash 3.2 pseudo-terminal, the
       deferred current-entry path, plain no-terminal output, and descriptor
       cleanup. Reproduced the missing bars through `ssh_current alex-work`,

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -74,7 +74,6 @@ SETUP_PROGRESS_TOTAL=0
 SETUP_PROGRESS_FAILED=0
 SETUP_PROGRESS_ENABLED=0
 SETUP_PROGRESS_PINNED=0
-SETUP_PROGRESS_OWNS_FD=0
 SETUP_PROGRESS_SPINNER_PID=""
 SETUP_PROGRESS_STARTED=0
 SETUP_PROGRESS_STEP_STARTED=0
@@ -108,18 +107,8 @@ setup_progress_start() {
 	# old in-memory code unable to pass the terminal through on that first run.
 	if [ "$SETUP_PROGRESS_TOTAL" -gt 0 ] &&
 		[ "${TERM:-dumb}" != dumb ] &&
-		[ ! -t 9 ] &&
-		{ exec 9<>/dev/tty; } 2>/dev/null; then
+		{ : </dev/tty >/dev/tty; } 2>/dev/null; then
 		PROFILE_SETUP_OUTPUT_TTY=1
-		PROFILE_SETUP_PROGRESS_FD=9
-		PROFILE_SETUP_DEFER_PROGRESS_FINISH=0
-		SETUP_PROGRESS_OWNS_FD=1
-	fi
-	if [ "$SETUP_PROGRESS_TOTAL" -gt 0 ] &&
-		[ "${PROFILE_SETUP_OUTPUT_TTY:-0}" = 1 ] &&
-		[ "${PROFILE_SETUP_PROGRESS_FD:-}" = 9 ] &&
-		[ "${TERM:-dumb}" != dumb ] &&
-		(: >&9) 2>/dev/null; then
 		SETUP_PROGRESS_ENABLED=1
 	fi
 	if [ "$SETUP_PROGRESS_ENABLED" -eq 1 ] && [ -z "${NO_COLOR:-}" ]; then
@@ -132,13 +121,13 @@ setup_progress_start() {
 }
 
 setup_progress_write() {
-	printf '%b' "$@" >&9 2>/dev/null || true
+	printf '%b' "$@" >/dev/tty 2>/dev/null || true
 }
 
 setup_progress_read_dimensions() {
 	local size rows columns label_width=28 bar_width=24
 
-	size="$(stty size <&9 2>/dev/null)" || return 1
+	size="$(stty size </dev/tty 2>/dev/null)" || return 1
 	rows=${size%% *}
 	columns=${size##* }
 	case "$rows:$columns" in
@@ -385,10 +374,6 @@ setup_progress_finish() {
 	fi
 	SETUP_PROGRESS_PINNED=0
 	SETUP_PROGRESS_ENABLED=0
-	if [ "$SETUP_PROGRESS_OWNS_FD" -eq 1 ]; then
-		exec 9>&-
-		SETUP_PROGRESS_OWNS_FD=0
-	fi
 }
 
 setup_progress_interrupt() {
@@ -493,8 +478,12 @@ run_function() {
 		set -e
 		set -o pipefail
 		trap 'handle_error $LINENO' ERR
-		"$func_name"
-	) 9>&-
+		if [ "${PROFILE_SETUP_PROGRESS_FD:-}" = 9 ] && [ -t 9 ]; then
+			"$func_name" 9>&-
+		else
+			"$func_name"
+		fi
+	)
 	exit_code=$?
 	if [ "$had_errexit" -eq 1 ]; then
 		set -e

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -74,6 +74,7 @@ SETUP_PROGRESS_TOTAL=0
 SETUP_PROGRESS_FAILED=0
 SETUP_PROGRESS_ENABLED=0
 SETUP_PROGRESS_PINNED=0
+SETUP_PROGRESS_OWNS_FD=0
 SETUP_PROGRESS_SPINNER_PID=""
 SETUP_PROGRESS_STARTED=0
 SETUP_PROGRESS_STEP_STARTED=0
@@ -103,6 +104,17 @@ setup_progress_start() {
 	SETUP_PROGRESS_MUTED=""
 	SETUP_PROGRESS_RESET=""
 
+	# The entry point may update itself before launching this script, leaving its
+	# old in-memory code unable to pass the terminal through on that first run.
+	if [ "$SETUP_PROGRESS_TOTAL" -gt 0 ] &&
+		[ "${TERM:-dumb}" != dumb ] &&
+		[ ! -t 9 ] &&
+		{ exec 9<>/dev/tty; } 2>/dev/null; then
+		PROFILE_SETUP_OUTPUT_TTY=1
+		PROFILE_SETUP_PROGRESS_FD=9
+		PROFILE_SETUP_DEFER_PROGRESS_FINISH=0
+		SETUP_PROGRESS_OWNS_FD=1
+	fi
 	if [ "$SETUP_PROGRESS_TOTAL" -gt 0 ] &&
 		[ "${PROFILE_SETUP_OUTPUT_TTY:-0}" = 1 ] &&
 		[ "${PROFILE_SETUP_PROGRESS_FD:-}" = 9 ] &&
@@ -373,6 +385,10 @@ setup_progress_finish() {
 	fi
 	SETUP_PROGRESS_PINNED=0
 	SETUP_PROGRESS_ENABLED=0
+	if [ "$SETUP_PROGRESS_OWNS_FD" -eq 1 ]; then
+		exec 9>&-
+		SETUP_PROGRESS_OWNS_FD=0
+	fi
 }
 
 setup_progress_interrupt() {


### PR DESCRIPTION
Uses the controlling terminal for first-run setup progress over SSH and cleans up runner-owned descriptors.

## Summary by Sourcery

Restore reliable first-run SSH setup progress without disrupting inherited descriptors or non-interactive execution.

Bug Fixes:
- Restore setup progress rendering on the first post-update SSH run by using the controlling terminal when available.
- Preserve non-interactive plain output and clean up only descriptors identified as progress terminals.

Enhancements:
- Make setup progress handling independent of stale entry-point state while preserving inherited logging and IPC descriptors.

Tests:
- Verify Bash compatibility, pseudo-terminal and no-terminal behavior, descriptor cleanup, formatting, linting, and the corrected SSH/Ubuntu execution paths.