### PR TITLE
fix(setup): target the managed pyenv interpreter

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,25 @@
+# Repair pyenv setup on externally managed Python hosts
+
+- [x] Detect and replace an incomplete pinned pyenv installation.
+- [x] Install base packages into the pinned pyenv interpreter, not `/usr`.
+- [x] Verify complete, incomplete, macOS, and failure paths locally.
+- [x] Run Bash syntax, formatting, focused ShellCheck, and diff checks.
+- [x] Review the final diff and record the outcome.
+
+## Review
+
+- [x] Setup now removes only the pinned pyenv version when its required
+      `bin/python` is missing, reinstalls it, and rejects another incomplete
+      result before changing the global version.
+- [x] `uv` receives the pinned interpreter explicitly, avoiding Ubuntu's
+      externally managed `/usr` Python and any unrelated active virtualenv.
+- [x] A remote dry run on `alex-work-old` confirmed the explicit interpreter
+      target. Throwaway complete, partial, failed-install, and macOS scenarios
+      pass locally.
+- [x] Bash 3.2 and current Bash syntax, shfmt, repository error-level
+      ShellCheck, and `git diff --check` pass. Warning-level ShellCheck retains
+      the same six existing findings as `main`.
+
 # Show setup progress on the first post-update run
 
 - [x] Confirm `ssh_current` allocates a terminal and diagnose the Ubuntu path.

--- a/tools/common.sh
+++ b/tools/common.sh
@@ -632,14 +632,20 @@ install_pyenv() {
 		source ~/.bashrc 2>/dev/null || true
 	fi
 
+	local pyenv_version_dir="$PYENV_ROOT/versions/$DEFAULT_PYTHON_VERSION"
+	local python_bin="$pyenv_version_dir/bin/python"
+	if [ -d "$pyenv_version_dir" ] && [ ! -x "$python_bin" ]; then
+		log "Removing incomplete Python $DEFAULT_PYTHON_VERSION installation"
+		pyenv uninstall -f "$DEFAULT_PYTHON_VERSION"
+	fi
+
 	# Install Python versions
 	if [ "$os_type" = "Darwin" ]; then
-		pyenv install -s $DEFAULT_PYTHON_VERSION
+		pyenv install -s "$DEFAULT_PYTHON_VERSION"
 
 		# Verify the installed Python matches the native architecture
 		local expected_arch
 		expected_arch="$(uname -m)"
-		local python_bin="$PYENV_ROOT/versions/$DEFAULT_PYTHON_VERSION/bin/python3"
 		if [ -f "$python_bin" ]; then
 			local binary_arch
 			binary_arch="$(file "$python_bin" | grep -o 'arm64\|x86_64' | head -1)"
@@ -657,6 +663,10 @@ install_pyenv() {
 		# Only one version is installed on purpose — extra minor versions slow
 		# down pyenv shim resolution (and the prompt) without much benefit.
 		pyenv install -s "$DEFAULT_PYTHON_VERSION"
+	fi
+	if [ ! -x "$python_bin" ]; then
+		log "ERROR: Python $DEFAULT_PYTHON_VERSION installation is incomplete"
+		return 1
 	fi
 	pyenv global "$DEFAULT_PYTHON_VERSION"
 
@@ -681,7 +691,8 @@ install_pyenv() {
 
 	# Install base Python packages
 	if command -v uv >/dev/null 2>&1; then
-		uv pip install --system pip-tools psutil
+		# `--system` selects Ubuntu's externally managed `/usr` interpreter.
+		uv pip install --python "$python_bin" pip-tools psutil
 	fi
 
 	# Create a default venv if needed (macOS convention)


### PR DESCRIPTION
Repair incomplete pinned pyenv installs and target that interpreter explicitly for base Python packages.

## Summary by Sourcery

Ensure setup reliably restores and explicitly targets the pinned pyenv interpreter for Python package installation.

Bug Fixes:
- Repair incomplete pinned pyenv installations by removing and reinstalling the affected Python version before activation.
- Install base Python packages into the pinned pyenv interpreter instead of the system-managed Python.

Enhancements:
- Validate that the pinned interpreter is complete before setting it as the global pyenv version, including on macOS.